### PR TITLE
log potential exception in "up" task

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -63,6 +63,7 @@ class ComposeUp extends DefaultTask {
             }
         }
         catch (Exception e) {
+            logger.debug("Failed to start-up Docker containers", e)
             downTask.down()
             throw e
         }


### PR DESCRIPTION
Potential exceptions in the "up" task are currently catched and the down task is executed:

```java
try {
    // […]
} catch (Exception e) {
    downTask.down()
    throw e
}
```

If the `downTask` itself throws an exception, the potential root cause is lost.
This change adds debug logging of the first exception.