### PR TITLE
Respect startedServices setting in getServiceNames()

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -84,7 +84,9 @@ class ComposeExecutor {
     }
 
     Iterable<String> getServiceNames() {
-        if (version >= VersionNumber.parse('1.6.0')) {
+        if (!extension.startedServices.empty){
+            extension.startedServices
+        } else if (version >= VersionNumber.parse('1.6.0')) {
             execute('config', '--services').readLines()
         } else {
             def composeFiles = extension.useComposeFiles.empty ? getStandardComposeFiles() : getCustomComposeFiles()


### PR DESCRIPTION
Fix an error for when the startedServices setting specifies only a
subset of the services defined in a docker-compose file and a service S
which is not in startedServices exposes a port.
Previously, loadServicesInfo() would iterate over all services in the
docker-compose file, notice that the port that S exposes can not be
found in NetworkSettings, and exit with a RuntimeException.
With this fix, if startedServices is set, we only iterate over the
services in startedServices.