### PR TITLE
down after partially failed compose up

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -1,6 +1,9 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.*
+import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ContainerInfo
+import com.avast.gradle.dockercompose.ServiceHost
+import com.avast.gradle.dockercompose.ServiceInfo
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 
@@ -46,8 +49,8 @@ class ComposeUp extends DefaultTask {
             args += settings.upAdditionalArgs
         }
         args += settings.startedServices
-        settings.composeExecutor.execute(args)
         try {
+            settings.composeExecutor.execute(args)
             if (settings.captureContainersOutput) {
                 settings.composeExecutor.captureContainersOutput(logger.&lifecycle)
             }


### PR DESCRIPTION
when containers depend on another container in the same compose up, the docker-compose up with "-d" argument will still wait for the dependencies with condition "service_healthy". If a dependency gets unhealthy the task will throw an exception and will not compose down properly for already existing containers.

moving the compose up into the try catch forces the compose down after failure of compose up to remove all remaining parts of the failed compose up