### PR TITLE
Update readme to match code

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ test.doFirst {
     // if service is scaled using scale option, environment variables will be exposed for each service instance like "web_1.host", "web_1.tcp.80", "web_2.host", "web_2.tcp.80" and so on
     dockerCompose.exposeAsSystemProperties(test)
     // get information about container of service `web` (declared in docker-compose.yml)
-    def webInfo = dockerCompose.servicesInfos.web.firstInstance
+    def webInfo = dockerCompose.servicesInfos.web.firstContainer
     // in case scale option is used, dockerCompose.servicesInfos.containerInfos will contain information about all running containers of service. Particular container can be retrieved either by iterating the values of containerInfos map (key is service instance name, for example 'web_1')
     def webInfo = dockerCompose.servicesInfos.web.'web_1'
     // pass host and exposed TCP port 80 as custom-named Java System properties


### PR DESCRIPTION
In this commit: https://github.com/avast/gradle-docker-compose-plugin/commit/dcabe18e21b9243639cb3deaa5ea98fbcb36e672#diff-edbbf5335359ba503cd97107e888cbe9

The method `getFirstInstance()` was renamed to `getFirstContainer()`, but the change was missed in the readme.