### PR TITLE
Honour startedServices setting when executing docker-compose stop

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -17,8 +17,12 @@ class ComposeDown extends DefaultTask {
     @TaskAction
     void down() {
         if (settings.stopContainers) {
-            settings.composeExecutor.execute('stop', '--timeout', settings.dockerComposeStopTimeout.getSeconds().toString())
+            settings.composeExecutor.execute('stop', '--timeout', settings.dockerComposeStopTimeout.getSeconds().toString(), *settings.startedServices)
             if (settings.removeContainers) {
+                if (!settings.startedServices.empty) {
+                    logger.warn("You have specified startedServices, but composeDown with removeContainers = true will " +
+                        "stop and remove all services defined in your compose file.")
+                }
                 if (settings.composeExecutor.version >= VersionNumber.parse('1.6.0')) {
                     String[] args = ['down']
                     switch (settings.removeImages) {


### PR DESCRIPTION
Instead of just printing a warning, one could also skip executing `docker-compose down` if there are more services defined in the compose configuration than there are in startedServices.