### PR TITLE
Link input and output of composeUp and composeDown tasks from isRequiredBy task

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,8 @@ dockerCompose {
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'
     // dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     // environment.put 'BACKEND_ADDRESS', '192.168.1.100' // Pass environment variable to 'docker-compose' for substitution in compose file
+
+    // inheritInputAndOutputs = false // when turned on it links input and output from `isRequiredBy` task and enables incremental building
 }
 
 test.doFirst {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -62,6 +62,8 @@ class ComposeSettings {
     String dockerComposeWorkingDirectory = null
     Duration dockerComposeStopTimeout = Duration.ofSeconds(10)
 
+    boolean inheritInputAndOutputs = false
+
     ComposeSettings(Project project, String name = '') {
         this.project = project
 
@@ -117,6 +119,16 @@ class ComposeSettings {
     }
 
     void isRequiredBy(Task task) {
+        if (inheritInputAndOutputs) {
+            upTask.inputs.files task.inputs.files
+            downTask.inputs.files task.inputs.files
+            upTask.outputs.upToDateWhen {
+                task
+            }
+            downTask.outputs.upToDateWhen {
+                task
+            }
+        }
         task.dependsOn upTask
         task.finalizedBy downTask
         def ut = upTask // to access private field from closure


### PR DESCRIPTION
Adds flag for linking input and output of composeUp and composeDown
tasks from isRequiredBy task. This allows incremental builds and avoid
the compose up and down when main task is up to date.

The flag is called `inheritInputAndOutputs` and by default is set to
false. This flag works only when isRequiredBy method is called.

This avoids declarations such as these:
```
composeUp {
    inputs.files test.inputs.files
    outputs.upToDateWhen {
        test
    }
}

composeDown {
    inputs.files test.inputs.files
    outputs.upToDateWhen {
        test
    }
}
```