### PR TITLE
Fix: Respect buildAdditionalArgs when using buildBeforeUp

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -41,7 +41,7 @@ class ComposeUp extends DefaultTask {
         settings.serviceInfoCache.clear()
         wasReconnected = false
         if (settings.buildBeforeUp) {
-            settings.composeExecutor.execute(*['build', *settings.startedServices])
+            settings.buildTask.build()
         }
         String[] args = ['up', '-d']
         if (settings.removeOrphans()) {


### PR DESCRIPTION
When `buildBeforeUp` is set to 'true' and `composeUp` will not build images with
additional arguments, but when called by `composePull` it uses the
additional arguments.

This changes makes both tasks respect the additional arguments.