### PR TITLE
Add `buildBeforePull` parameter for running `build` before `pull`

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ dockerCompose {
     // scale = [${serviceName1}: 5, ${serviceName2}: 2] // Pass docker compose --scale option like 'docker-compose up --scale serviceName1=5 --scale serviceName2=2'
     // forceRecreate = false // pass '--force-recreate' when calling 'docker-compose up' when set to 'true`
     // buildBeforeUp = true // performs 'docker-compose build' before calling the 'up' command; default is true
+    // buildBeforePull = true // performs 'docker-compose build' before calling the 'pull' command; default is true
     // ignorePullFailure = false // when set to true, pass '--ignore-pull-failure' to 'docker-compose pull'
     // buildAdditionalArgs = ['--force-rm']
     // pullAdditionalArgs = ['--ignore-pull-failures']
@@ -154,3 +155,8 @@ It's very handy in scenarios when you iterate quickly and e.g. don't want to wai
 * Check [ContainerInfo.groovy](/src/main/groovy/com/avast/gradle/dockercompose/ContainerInfo.groovy) to see what you can know about running containers.
 * You can determine the Docker host in your Gradle build (i.e. `docker-machine start`) and set the `DOCKER_HOST` environment variable for compose to use: `dockerCompose { environment.put 'DOCKER_HOST', '192.168.64.9' }`
 * If the services executed by `docker-compose` are running on a specific host (different than Docker, like in CirceCI 2.0), then `SERVICES_HOST` environment variable can be used. This value will be used as the hostname where the services are expected to be listening.
+
+# Release notes
+## 0.8.0
+* New parameter `buildBeforePull` that runs `docker-compose build` before `composePull` task. Previously this behaviour 
+was set by `buildBeforeUp`. The `buildBeforePull` parameter is currently used onl for `composeUp` task.

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -27,6 +27,7 @@ class ComposeSettings {
     final ServiceInfoCache serviceInfoCache
 
     boolean buildBeforeUp = true
+    boolean buildBeforePull = true
     boolean waitForTcpPorts = true
     boolean captureContainersOutput = false
     File captureContainersOutputToFile = null
@@ -91,6 +92,7 @@ class ComposeSettings {
     ComposeSettings createNested(String name) {
         def r = new ComposeSettings(project, name)
         r.buildBeforeUp = this.buildBeforeUp
+        r.buildBeforePull = this.buildBeforePull
         r.waitForTcpPorts = this.waitForTcpPorts
         r.captureContainersOutput = this.captureContainersOutput
         r.waitAfterTcpProbeFailure = this.waitAfterTcpProbeFailure

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
@@ -17,7 +17,7 @@ class ComposePull extends DefaultTask {
 
     @TaskAction
     void pull() {
-        if (settings.buildBeforeUp) {
+        if (settings.buildBeforePull) {
             settings.buildTask.build()
         }
         String[] args = ['pull']


### PR DESCRIPTION
New parameter `buildBeforePull` that runs `docker-compose build` before
`composePull` task. Previously this behaviour was set by `buildBeforeUp`.
The `buildBeforePull` parameter is currently used only for `composeUp` task.

