### PR TITLE
Add `composePush` task

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Simplifies usage of [Docker Compose](https://www.docker.com/docker-compose) for 
 
 `composeBuild` task builds the services of the application.
 
+`composePush` task pushes images for services to their respective `registry/repository`
+
 ## Quick start
 ```gradle
 buildscript {
@@ -75,6 +77,8 @@ dockerCompose {
     // forceRecreate = false // pass '--force-recreate' when calling 'docker-compose up' when set to 'true`
     // buildBeforeUp = true // performs 'docker-compose build' before calling the 'up' command; default is true
     // ignorePullFailure = false // when set to true, pass '--ignore-pull-failure' to 'docker-compose pull'
+    // ignorePushFailure = false // when set to true, pass '--ignore-push-failure' to 'docker-compose push'
+    // pushServices = [] // which services should be pushed, if not defined then upon `composePush` task all defined services in compose file will be pushed (default behaviour)
     // buildAdditionalArgs = ['--force-rm']
     // pullAdditionalArgs = ['--ignore-pull-failures']
     // upAdditionalArgs = ['--no-deps']
@@ -118,7 +122,7 @@ test.doFirst {
 ```
 
 ## Nested configurations
-It is possible to create a new set of `ComposeUp`/`ComposeBuild`/`ComposePull`/`ComposeDown` tasks using following syntax:
+It is possible to create a new set of `ComposeUp`/`ComposeBuild`/`ComposePull`/`ComposeDown`/`ComposeDownForced`/`ComposePush` tasks using following syntax:
 ```gradle
 dockerCompose {
     // settings as usual
@@ -128,7 +132,7 @@ dockerCompose {
     }
 }
 ```
-* It creates `myNestedComposeUp`, `myNestedComposeBuild`, `myNestedComposePull` and `myNestedComposeDown` tasks.
+* It creates `myNestedComposeUp`, `myNestedComposeBuild`, `myNestedComposePull`, `myNestedComposeDown`, `myNestedComposeDownForced` and `myNestedComposePush` tasks.
 * It's possible to use all the settings as in the main `dockerCompose` block.
 * Configuration of the nested settings defaults to the main `dockerCompose` settings.
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -4,6 +4,7 @@ import com.avast.gradle.dockercompose.tasks.ComposeBuild
 import com.avast.gradle.dockercompose.tasks.ComposeDown
 import com.avast.gradle.dockercompose.tasks.ComposeDownForced
 import com.avast.gradle.dockercompose.tasks.ComposePull
+import com.avast.gradle.dockercompose.tasks.ComposePush
 import com.avast.gradle.dockercompose.tasks.ComposeUp
 import com.avast.gradle.dockercompose.tasks.ServiceInfoCache
 import org.gradle.api.Project
@@ -21,6 +22,7 @@ class ComposeSettings {
     final ComposeDownForced downForcedTask
     final ComposeBuild buildTask
     final ComposePull pullTask
+    final ComposePush pushTask
     final Project project
     final DockerExecutor dockerExecutor
     final ComposeExecutor composeExecutor
@@ -53,6 +55,8 @@ class ComposeSettings {
     boolean removeVolumes = true
 
     boolean ignorePullFailure = false
+    boolean ignorePushFailure = false
+    List<String> pushServices = []
 
     String executable = 'docker-compose'
     Map<String, Object> environment = new HashMap<String, Object>(System.getenv())
@@ -75,6 +79,8 @@ class ComposeSettings {
         downTask.settings = this
         downForcedTask = project.tasks.create(name ? "${name}ComposeDownForced" : 'composeDownForced', ComposeDownForced)
         downForcedTask.settings = this
+        pushTask = project.tasks.create(name ? "${name}ComposePush" : 'composePush', ComposePush)
+        pushTask.settings = this
 
         this.dockerExecutor = new DockerExecutor(this)
         this.composeExecutor = new ComposeExecutor(this)
@@ -105,6 +111,9 @@ class ComposeSettings {
         r.removeVolumes = this.removeVolumes
         r.removeOrphans = this.removeOrphans
         r.forceRecreate = this.forceRecreate
+
+        r.ignorePullFailure = this.ignorePullFailure
+        r.ignorePushFailure = this.ignorePushFailure
 
         r.executable = this.executable
         r.environment = new HashMap<>(this.environment)

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePush.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePush.groovy
@@ -1,0 +1,25 @@
+package com.avast.gradle.dockercompose.tasks
+
+import com.avast.gradle.dockercompose.ComposeSettings
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class ComposePush extends DefaultTask {
+
+    ComposeSettings settings
+
+    ComposePush() {
+        group = 'docker'
+        description = 'Pushes images for services of docker-compose project'
+    }
+
+    @TaskAction
+    void push() {
+        String[] args = ['push']
+        if (settings.ignorePushFailure) {
+            args += '--ignore-push-failures'
+        }
+        args += settings.pushServices
+        settings.composeExecutor.execute(args)
+    }
+}

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -4,8 +4,8 @@ import com.avast.gradle.dockercompose.tasks.ComposeBuild
 import com.avast.gradle.dockercompose.tasks.ComposeDown
 import com.avast.gradle.dockercompose.tasks.ComposeDownForced
 import com.avast.gradle.dockercompose.tasks.ComposePull
+import com.avast.gradle.dockercompose.tasks.ComposePush
 import com.avast.gradle.dockercompose.tasks.ComposeUp
-import groovy.ui.SystemOutputInterceptor
 import org.gradle.api.Task
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testfixtures.ProjectBuilder
@@ -24,6 +24,7 @@ class DockerComposePluginTest extends Specification {
             project.tasks.composeDown instanceof ComposeDown
             project.tasks.composeDownForced instanceof ComposeDownForced
             project.tasks.composePull instanceof ComposePull
+            project.tasks.composePush instanceof ComposePush
             project.tasks.composeBuild instanceof ComposeBuild
             project.extensions.findByName('dockerCompose') instanceof ComposeExtension
     }
@@ -42,6 +43,7 @@ class DockerComposePluginTest extends Specification {
         project.tasks.nestedComposeDown instanceof ComposeDown
         project.tasks.nestedComposeDownForced instanceof ComposeDownForced
         project.tasks.nestedComposePull instanceof ComposePull
+        project.tasks.composePush instanceof ComposePush
         project.tasks.nestedComposeBuild instanceof ComposeBuild
         ComposeUp up = project.tasks.nestedComposeUp
         up.settings.useComposeFiles == ['test.yml']
@@ -69,11 +71,17 @@ class DockerComposePluginTest extends Specification {
             nested {
                 useComposeFiles = ['test.yml']
                 removeVolumes = false
+                ignorePullFailure = true
+                ignorePushFailure = true
             }
         }
         then:
         project.dockerCompose.nested.removeVolumes == false
         project.dockerCompose.removeVolumes == true
+        project.dockerCompose.ignorePullFailure == false
+        project.dockerCompose.ignorePushFailure == false
+        project.dockerCompose.nested.ignorePullFailure == true
+        project.dockerCompose.nested.ignorePushFailure == true
     }
 
     def "isRequiredBy() adds dependencies"() {
@@ -116,6 +124,7 @@ class DockerComposePluginTest extends Specification {
         project.tasks.integrationTestComposeDown instanceof ComposeDown
         project.tasks.integrationTestComposeDownForced instanceof ComposeDownForced
         project.tasks.integrationTestComposePull instanceof ComposePull
+        project.tasks.integrationTestComposePush instanceof ComposePush
         project.tasks.integrationTestComposeBuild instanceof ComposeBuild
         ComposeUp up = project.tasks.integrationTestComposeUp
         up.settings.useComposeFiles == ['test.yml']


### PR DESCRIPTION
Adds `composePush` task which adds push tasks for built images. Allows
to set `ignorePushFailure` option to ignore failures during pushing.

The task will push specified services in compose file.