### PR TITLE
Project name derived from project absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ dockerCompose {
     // removeVolumes = true
     // removeOrphans = false // removes containers for services not defined in the Compose file
     
-    // projectName = 'my-project' // allow to set custom docker-compose project name (defaults to directory name)
+    // projectName = 'my-project' // allow to set custom docker-compose project name (defaults to a stable name derived from absolute path of the project), set to null to Docker Compose default (directory name)
     // executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (useful if not present in PATH)
     // dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (useful if not present in PATH)
     // dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -13,6 +13,8 @@ import org.gradle.process.JavaForkOptions
 import org.gradle.process.ProcessForkOptions
 import org.gradle.util.VersionNumber
 
+import java.nio.charset.StandardCharsets
+import java.security.MessageDigest
 import java.time.Duration
 
 class ComposeSettings {
@@ -46,7 +48,7 @@ class ComposeSettings {
     List<String> pullAdditionalArgs = []
     List<String> upAdditionalArgs = []
     List<String> downAdditionalArgs = []
-    String projectName = null
+    String projectName
 
     boolean stopContainers = true
     boolean removeContainers = true
@@ -80,6 +82,9 @@ class ComposeSettings {
         this.dockerExecutor = new DockerExecutor(this)
         this.composeExecutor = new ComposeExecutor(this)
         this.serviceInfoCache = new ServiceInfoCache(this)
+
+        def fullPathMd5 = MessageDigest.getInstance("MD5").digest(project.projectDir.absolutePath.toString().getBytes(StandardCharsets.UTF_8)).encodeHex().toString()
+        this.projectName = fullPathMd5 + '_' + project.name + '_' + name
 
         if (OperatingSystem.current().isMacOsX()) {
             // Default installation is inaccessible from path, so set sensible


### PR DESCRIPTION
We don't have to sanitize the project name because it's already done [in docker-compose](https://github.com/docker/compose/blob/master/compose/cli/command.py#L138).