### PR TITLE
Adds removeDependents feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ dockerCompose {
     removeImages = "None" // Other accepted values are: "All" and "Local"
     removeVolumes = true
     removeOrphans = false // removes containers for services not defined in the Compose file
+    removeDependents = false // calculates services dependencies of startedServices and removes those as well
     
     projectName = 'my-project' // allow to set custom docker-compose project name (defaults to a stable name derived from absolute path of the project), set to null to Docker Compose default (directory name)
     executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (useful if not present in PATH)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
@@ -31,7 +31,17 @@ class ComposeConfigParser
             def dependencies = []
             if (service.depends_on)
             {
-                dependencies.addAll(service.depends_on)
+                def serviceDeps = service.depends_on
+                // just a list of services without properties
+                if(serviceDeps instanceof  List)
+                {
+                    dependencies.addAll(serviceDeps)
+                }
+                // services that have properties
+                if(serviceDeps instanceof  Map)
+                {
+                    dependencies.addAll(serviceDeps.keySet())
+                }
             }
             // in version one, links established service names
             if (service.links)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
@@ -9,7 +9,7 @@ import org.yaml.snakeyaml.Yaml
 class ComposeConfigParser
 {
     /**
-     * Given the result of docker-compose config, parses through the output and builds a dependency graph between a service and the service's dependencies. The full graph is travers, such that children dependencies are calculated
+     * Given the result of docker-compose config, parses through the output and builds a dependency graph between a service and the service's dependencies. The full graph is traversed, such that child dependencies are calculated
      * @param composeConfigOutput the output of docker-compose config
      * @return a map of a service's dependencies keyed by the service.
      */

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
@@ -1,0 +1,79 @@
+package com.avast.gradle.dockercompose
+
+import org.gradle.internal.impldep.com.google.common.annotations.VisibleForTesting
+import org.yaml.snakeyaml.Yaml
+
+/**
+ * Reads information from the output of docker-compose config
+ */
+class ComposeConfigParser
+{
+    /**
+     * Given the result of docker-compose config, parses through the output and builds a dependency graph between a service and the service's dependencies. The full graph is travers, such that children dependencies are calculated
+     * @param composeConfigOutput the output of docker-compose config
+     * @return a map of a service's dependencies keyed by the service.
+     */
+    static Map<String, Set<String>> findServiceDependencies (String composeConfigOutput)
+    {
+        Yaml parser = new Yaml()
+        def result = parser.load(composeConfigOutput)
+
+        // if there is 'version' on top-level then information about services is in 'services' sub-tree
+        def serviceList = result.version ? result.services : result
+
+        def declaredServiceDependencies = [:]
+        def services = serviceList.entrySet()
+
+        services.each { entry ->
+            def serviceName = entry.getKey()
+            def service = entry.getValue()
+
+            def dependencies = []
+            if (service.depends_on)
+            {
+                dependencies.addAll(service.depends_on)
+            }
+            // in version one, links established service names
+            if (service.links)
+            {
+                dependencies.addAll(service.links)
+            }
+
+            declaredServiceDependencies.put(serviceName, dependencies)
+        }
+
+        // compute the graph for each service
+        def serviceDependencySet = [:]
+        services.each { entry ->
+            def service = entry.getKey()
+            serviceDependencySet.put(service, calculateDependenciesFromGraph(service, declaredServiceDependencies))
+        }
+
+        return serviceDependencySet
+    }
+
+    /**
+     * Given a map of a service's declared dependencies, calculates the full dependency set for a given service.
+     * @param declaredDependencies a map of service's dependencies
+     * @return a set of the service's full dependencies
+     */
+    @VisibleForTesting
+    protected  static Set<String> calculateDependenciesFromGraph(String serviceName, Map<String, Set<String>> declaredDependencies) {
+
+        def toVisit = []
+        toVisit.add(serviceName)
+
+        Set<String> serviceDependencies = []
+
+        while(!toVisit.isEmpty()) {
+            String visitedService = toVisit.removeAt(0)
+            def dependents = declaredDependencies.get(visitedService)
+            if(dependents) {
+                toVisit.addAll(dependents)
+                serviceDependencies.addAll(dependents)
+            }
+        }
+
+        serviceDependencies
+    }
+}

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -130,6 +130,27 @@ class ComposeExecutor {
         }
     }
 
+    /**
+     * Calculates dependent services for the given set of services. The full dependency graph will be calculated, such that transitive dependencies will be returned.
+     * @param serviceNames the name of services to calculate dependencies for
+     * @return the set of services that are dependencies of the given services
+     */
+    Iterable<String> getDependentServices(Iterable<String> serviceNames) {
+        def configOutput = execute('config')
+        def dependencyGraph = ComposeConfigParser.findServiceDependencies(configOutput)
+
+        def dependentServices = []
+
+        serviceNames.each { service ->
+            def serviceDeps = dependencyGraph[service]
+            if(serviceDeps) {
+                dependentServices.addAll(serviceDeps)
+            }
+        }
+
+        dependentServices
+    }
+
     Iterable<File> getStandardComposeFiles() {
         def res = []
         def f = findInParentDirectories('docker-compose.yml', project.projectDir)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -64,6 +64,7 @@ class ComposeSettings {
     boolean removeContainers = true
     RemoveImages removeImages = RemoveImages.None
     boolean removeVolumes = true
+    boolean removeDependents = false
 
     boolean ignorePullFailure = false
     boolean ignorePushFailure = false
@@ -142,6 +143,7 @@ class ComposeSettings {
         r.removeContainers = this.removeContainers
         r.removeImages = this.removeImages
         r.removeVolumes = this.removeVolumes
+        r.removeDependents = this.removeDependents
 
         r.ignorePullFailure = this.ignorePullFailure
         r.ignorePushFailure = this.ignorePushFailure

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -26,7 +26,7 @@ class ComposeDownForced extends DefaultTask {
             }
         }
 
-        def servicesToStop = [*settings.startedServices, *dependentServices]
+        def servicesToStop = [*settings.startedServices, *dependentServices].unique()
 
         settings.serviceInfoCache.clear()
         settings.composeExecutor.execute(*['stop', '--timeout', settings.dockerComposeStopTimeout.getSeconds().toString(), *servicesToStop])

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -9,8 +9,6 @@ import org.gradle.util.VersionNumber
 class ComposeDownForced extends DefaultTask {
     ComposeSettings settings
 
-    List<String> dependentServices = [] // for testing
-
     ComposeDownForced() {
         group = 'docker'
         description = 'Stops and removes containers of docker-compose project'
@@ -19,6 +17,7 @@ class ComposeDownForced extends DefaultTask {
     @TaskAction
     void down() {
 
+        def dependentServices = []
         if(settings.removeDependents) {
             if(settings.startedServices)
             {

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
@@ -63,7 +63,7 @@ class ComposeConfigParserTest extends Specification
         def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
 
         then: "master has two dependencies"
-        dependenciesMap["master"].size() == ["slave0", "slave1"] as Set
+        dependenciesMap["master"] == ["slave0", "slave1"] as Set
 
         and: "slave0 has no dependencies"
         dependenciesMap["slave0"].isEmpty()

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
@@ -1,0 +1,183 @@
+package com.avast.gradle.dockercompose
+
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Verifies behavior of ComposeConfigParser
+ */
+class ComposeConfigParserTest extends Specification
+{
+
+    def "findServiceDependencies with a service two direct dependencies in version 3" ()
+    {
+        given: "compose config output for a service"
+        def configOutput = """
+            services:
+              master:
+                depends_on:
+                  - slave0
+                  - slave2
+              slave0:
+                expose:
+                  - '22'
+              slave1:
+                expose:
+                  - '23'
+            version: '3.0'
+        """
+
+        when: "findServiceDependencies is called"
+        def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
+
+        then: "master has two dependencies"
+        dependenciesMap["master"].size() == 2
+
+        and: "slave0 has no dependencies"
+        dependenciesMap["slave0"].isEmpty()
+
+        and: "slave1 has no dependencies"
+        dependenciesMap["slave1"].isEmpty()
+    }
+
+    def "findServiceDependencies with a service two direct dependencies in version 1" ()
+    {
+
+        given: "compose config output for a service"
+        def configOutput = """
+        master:
+          links:
+            - slave0
+            - slave2
+        slave0:
+            expose:
+              - '22'
+        slave1:
+            expose:
+              - '23'
+        """
+
+        when: "findServiceDependencies is called"
+        def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
+
+        then: "master has two dependencies"
+        dependenciesMap["master"].size() == 2
+
+        and: "slave0 has no dependencies"
+        dependenciesMap["slave0"].isEmpty()
+
+        and: "slave1 has no dependencies"
+        dependenciesMap["slave1"].isEmpty()
+    }
+
+    def "findServiceDependencies with a service 4 indirect dependencies in version 3" ()
+    {
+        given: "compose config output for a service"
+        def configOutput = """
+            services:
+              db:
+                expose:
+                  - 1414
+              splunkForward:
+                expose:
+                  - 8444
+              dataService:
+                depends_on:
+                  - db
+                expose:
+                  - '8080'
+              audit:
+                depends_on:
+                  - splunkForward
+              ui:
+                depends_on:
+                  - dataService
+                  - audit
+                expose:
+                  - '23'
+            version: '3.0'
+        """
+
+        when: "findServiceDependencies is called"
+        def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
+
+        then: "ui has 4 dependencies (audit, splunkForward, dataService, db)"
+        dependenciesMap["ui"] == ["audit", "splunkForward", "dataService", "db"] as Set
+    }
+
+    def "findServiceDependencies with a service 4 indirect dependencies in version 1" ()
+    {
+        given: "compose config output for a service"
+        def configOutput = """
+              db:
+                expose:
+                  - 1414
+              splunkForward:
+                expose:
+                  - 8444
+              dataService:
+                links:
+                  - db
+                expose:
+                  - '8080'
+              audit:
+                links:
+                  - splunkForward
+              ui:
+                links:
+                  - dataService
+                  - audit
+                expose:
+                  - '23'
+        """
+
+        when: "findServiceDependencies is called"
+        def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
+
+        then: "ui has 4 dependencies (audit, splunkForward, dataService, db)"
+        dependenciesMap["ui"] == ["audit", "splunkForward", "dataService", "db"] as Set
+    }
+
+    @Unroll
+    def "calculateDependenciesFromGraph computes dependencies for #service" ()
+    {
+        given: "a dependency graph"
+
+        /**
+         * services:
+         *   a:
+         *   b:
+         *     depends_on:
+         *       - a
+         *   c:
+         *     depends_on:
+         *       - b
+         *   d:
+         *   e:
+         *     depends_on:
+         *       - c
+         *       - d
+         */
+        def dependencyGraph = [
+                    "a":[],
+                    "b": ["a"],
+                    "c": ["b"],
+                    "d": [],
+                    "e": ["c", "d"]
+        ]
+
+        when: "calculateDependenciesFromGraph is called for #service"
+        def dependencies = ComposeConfigParser.calculateDependenciesFromGraph(service, dependencyGraph)
+
+        then: "the service's dependency set is calculated correctly"
+        dependencies == expectedSet
+
+        where:
+        service | expectedSet
+        "a" | [] as Set
+        "b" | ["a"] as Set
+        "c" | ["a", "b"] as Set
+        "d" | [] as Set
+        "e" | ["a", "b", "c", "d"] as Set
+    }
+}

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeConfigParserTest.groovy
@@ -18,7 +18,7 @@ class ComposeConfigParserTest extends Specification
                 depends_on:
                   slave0:
                     condition: service_healthy
-                  slave2:
+                  slave1:
                     condition: service_healthy
               slave0:
                 expose:
@@ -33,7 +33,7 @@ class ComposeConfigParserTest extends Specification
         def dependenciesMap = ComposeConfigParser.findServiceDependencies(configOutput)
 
         then: "master has two dependencies"
-        dependenciesMap["master"] == ["slave0", "slave2"] as Set
+        dependenciesMap["master"] == ["slave0", "slave1"] as Set
 
         and: "slave0 has no dependencies"
         dependenciesMap["slave0"].isEmpty()

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -413,4 +413,59 @@ class DockerComposePluginTest extends Specification {
                       - 80
         ''']
     }
+
+    def "removeDependents calculates dependencies correctly"() {
+        def f = Fixture.custom(composeFileContent)
+        f.project.plugins.apply 'java'
+        f.project.dockerCompose.removeDependents = true
+        f.project.dockerCompose.startedServices = ['webMaster']
+        f.project.plugins.apply 'docker-compose'
+        f.project.tasks.composeUp.up()
+        Test test = f.project.tasks.test as Test
+        when:
+        f.project.tasks.composeDown.down()
+        then:
+        f.project.tasks.composeDown.dependentServices as Set == ['web0', 'web1'] as Set
+        cleanup:
+        f.close()
+        where:
+        // test it for both compose file version 1 and 2
+        composeFileContent << ['''
+            web0:
+                image: nginx:stable
+                ports:
+                  - 80
+            web1:
+                image: nginx:stable
+                ports:
+                  - 80
+                links:
+                  - web0
+            webMaster:
+                image: nginx:stable
+                ports:
+                  - 80
+                links:
+                  - web1
+        ''', '''
+            version: '2'
+            services:
+                web0:
+                    image: nginx:stable
+                    ports:
+                      - 80
+                web1:
+                    image: nginx:stable
+                    ports:
+                      - 80
+                    links:
+                      - web0
+                webMaster:
+                    image: nginx:stable
+                    ports:
+                      - 80
+                    links:
+                      - web1
+        ''']
+    }
 }

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -425,7 +425,11 @@ class DockerComposePluginTest extends Specification {
         when:
         f.project.tasks.composeDown.down()
         then:
-        f.project.tasks.composeDown.dependentServices as Set == ['web0', 'web1'] as Set
+        def runningServices = f.project.dockerCompose.composeExecutor.execute('ps')
+        !runningServices.contains("webMaster")
+        !runningServices.contains("web0")
+        !runningServices.contains("web1")
+
         cleanup:
         f.close()
         where:


### PR DESCRIPTION
Fixes #187 

Adds a feature that computes the dependencies of services started and passes those down when composing.

Tested this locally by using `maven-publish` and `publishToLocal`, I see this bringing down my dependencies and having more args in "Going to remove"