### PR TITLE
allow specifying projectNamePrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ dockerCompose {
     removeVolumes = true // default is true
     removeOrphans = false // removes containers for services not defined in the Compose file; default is false
     
-    projectName = 'my-project' // allow to set custom docker-compose project name (defaults to a stable name derived from absolute path of the project and nested settings name), set to null to Docker Compose default (directory name)
+    projectName = 'my-project' // allow to set custom docker-compose project name (defaults to projectNamePrefix-project.name-nested_project.name), set to null to Docker Compose default (directory name)
+    projectNamePrefix = 'build-88' // used to create a safe projectName. if empty it will be derived from absolute path of the project
     executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (useful if not present in PATH)
     dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (useful if not present in PATH)
     dockerComposeWorkingDirectory = '/path/where/docker-compose/is/invoked/from'

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -40,8 +40,8 @@ class ComposeExecutor {
                 finalArgs.add('--no-ansi')
             }
             finalArgs.addAll(ex.useComposeFiles.collectMany { ['-f', it].asCollection() })
-            if (ex.projectName) {
-                finalArgs.addAll(['-p', ex.projectName])
+            if (ex.projectName != null) {
+                finalArgs.addAll(['-p', ex.generateProjectName()])
             }
             finalArgs.addAll(args)
             e.commandLine finalArgs

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -64,6 +64,7 @@ class ComposeSettings {
     List<String> upAdditionalArgs = []
     List<String> downAdditionalArgs = []
     String projectName
+    String projectNamePrefix
 
     boolean stopContainers = true
     boolean removeContainers = true
@@ -98,7 +99,7 @@ class ComposeSettings {
         this.composeExecutor = new ComposeExecutor(this)
         this.serviceInfoCache = new ServiceInfoCache(this)
 
-        this.projectName = this.projectName ?: generateProjectName(project, name)
+        this.projectName = this.projectName ?: generateProjectName(project, name, this.projectNamePrefix)
 
         this.containerLogToDir = project.buildDir.toPath().resolve('containers-logs').toFile()
 
@@ -110,9 +111,10 @@ class ComposeSettings {
         }
     }
 
-    private static String generateProjectName(Project project, String name) {
-        def fullPathMd5 = MessageDigest.getInstance("MD5").digest(project.projectDir.absolutePath.toString().getBytes(StandardCharsets.UTF_8)).encodeHex().toString()
-        "${fullPathMd5}_${project.name}_${name}"
+    private static String generateProjectName(Project project, String name, String prefix) {
+        def safe_prefix = prefix ?: MessageDigest.getInstance("MD5")
+                .digest(project.projectDir.absolutePath.toString().getBytes(StandardCharsets.UTF_8)).encodeHex().toString()
+        "${safe_prefix}_${project.name}_${name}"
     }
 
     ComposeSettings createNested(String name) {


### PR DESCRIPTION
closes #231


Example Usage:

Imagine the CI/build environment sets PIPELINE_ID to something like GIT_BRANCH-BUILD_NUMBER, e.g. `master-88`. We can use this to prefix our compose project name and support concurrent builds via:

```
dockerCompose {
    removeOrphans = true
    projectNamePrefix = System.getenv("PIPELINE_ID") ?: "local-0"
    ...
}
```