### PR TITLE
Fix problems with services scaled to 0

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfo.groovy
@@ -8,16 +8,16 @@ class ServiceInfo {
     /* Key is instance name, for example service_1 */
     Map<String, ContainerInfo> containerInfos = [:]
 
-    String getHost() { firstContainer.serviceHost.host }
-    Map<Integer, Integer> getPorts() { firstContainer.tcpPorts }
-    Map<Integer, Integer> getTcpPorts() { firstContainer.tcpPorts }
-    Map<Integer, Integer> getUdpPorts() { firstContainer.udpPorts }
-    Integer getPort() { firstContainer.port }
-    Integer getTcpPort() { firstContainer.tcpPort }
-    Integer getUdpPort() { firstContainer.udpPort }
-    
+    String getHost() { firstContainer?.serviceHost.host }
+    Map<Integer, Integer> getPorts() { tcpPorts }
+    Map<Integer, Integer> getTcpPorts() { firstContainer?.tcpPorts ?: [:] }
+    Map<Integer, Integer> getUdpPorts() { firstContainer?.udpPorts ?: [:] }
+    Integer getPort() { firstContainer?.port }
+    Integer getTcpPort() { firstContainer?.tcpPort }
+    Integer getUdpPort() { firstContainer?.udpPort }
+
     ContainerInfo getFirstContainer() {
-        containerInfos.values().first()
+        containerInfos.values()?.find()
     }
 
     def propertyMissing(String name) {


### PR DESCRIPTION
Printing out the exposed ports may cause an exception if there is a service without an instance in `servicesInfos`. See the included test for a reproduction.

This change lets `ServiceInfo` handle uninstantiated services in a save manner. This fixes the exception during `composeUp`.