### PR TITLE
Avoid resolving dependencies at configuration time

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -185,13 +185,12 @@ class ComposeSettings {
     void isRequiredByCore(Task task, boolean fromConfigure) {
         task.dependsOn upTask
         task.finalizedBy downTask
-        task.getTaskDependencies().getDependencies(task)
-                .findAll { Task.class.isAssignableFrom(it.class) && ((Task) it).name.toLowerCase().contains('classes') }
-                .each { dep ->
+        project.tasks.findAll { Task.class.isAssignableFrom(it.class) && ((Task) it).name.toLowerCase().contains('classes') }
+                .each { classesTask ->
                     if (fromConfigure) {
-                        upTask.get().shouldRunAfter dep
+                        upTask.get().shouldRunAfter classesTask
                     } else {
-                        upTask.configure { it.shouldRunAfter dep }
+                        upTask.configure { it.shouldRunAfter classesTask }
                     }
                 }
         if (task instanceof ProcessForkOptions) task.doFirst { exposeAsEnvironment(task as ProcessForkOptions) }


### PR DESCRIPTION
Fixes https://github.com/avast/gradle-docker-compose-plugin/issues/263.

In most cases, checking the dependency tree is not necessary, as `shouldRunAfter` does not add any tasks to the task graph. I think it's simpler to add the task ordering to all `classes` tasks in the project.

However, this does change the behavior in certain cases. For example, if someone runs `./gradlew classes composeUp` with no `isRequiredBy`, currently the plugin will have no ordering between the two tasks. These use cases seem unlikely to me though.

I can change the implementation to use `taskGraph.whenReady` if you think that's better. That implementation is just harder to unit test, as it relies on Gradle's API.