### PR TITLE
feat: API for nested settings reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ test.doFirst {
 
 ```kotlin
 test.doFirst {
-    dockerCompose.nested("myNested").exposeAsEnvironment(test)
+    dockerCompose.nested("myNested").exposeAsEnvironment(project.tasks.named("test").get())
 }
 ```    
 

--- a/README.md
+++ b/README.md
@@ -162,13 +162,13 @@ dockerCompose {
 ```kotlin
 dockerCompose {
     // settings as usual
-    createNested("myNested").apply {
+    nested("myNested").apply {
         useComposeFiles = listOf("docker-compose-for-integration-tests.yml")
         isRequiredBy(project.tasks.named("myTask").get())
     }
 }
-```
-    
+```    
+
 </details>
 
 
@@ -177,11 +177,22 @@ dockerCompose {
 * Configuration of the nested settings defaults to the main `dockerCompose` settings (declared before the nested settings), except following properties: `projectName`, `startedServices`, `useComposeFiles`, `scale`, `captureContainersOutputToFile`, `captureContainersOutputToFiles`, `composeLogToFile`, `containerLogToDir`, `pushServices`
 
 When exposing service info from `myNestedComposeUp` task into your task you should use following syntax:
-```
+```groovy
 test.doFirst {
-    dockerCompose.myNested.exposeAsEnvironment(test)  
+    dockerCompose.myNested.exposeAsEnvironment(test)
 }
 ```
+
+<details>
+<summary>Kotlin</summary>
+
+```kotlin
+test.doFirst {
+    dockerCompose.nested("myNested").exposeAsEnvironment(test)
+}
+```    
+
+</details>
 
 It's also possible to use this simplified syntax:
 ```gradle

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -11,7 +11,15 @@ class ComposeExtension extends ComposeSettings {
     private HashMap<String, ComposeSettings> settings = [:]
 
     private ComposeSettings getOrCreateNested(String name) {
-        settings.computeIfAbsent(name, { createNested(name) })
+        settings.computeIfAbsent(name, { cloneAsNested(name) })
+    }
+
+    ComposeSettings createNested(String name) {
+        getOrCreateNested(name)
+    }
+
+    ComposeSettings nested(String name) {
+        getOrCreateNested(name)
     }
 
     def propertyMissing(String name) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -135,7 +135,7 @@ class ComposeSettings {
         "${fullPathMd5}_${project.name}"
     }
 
-    ComposeSettings createNested(String name) {
+    protected ComposeSettings cloneAsNested(String name) {
         def r = new ComposeSettings(project, name, this.nestedName)
         r.buildBeforeUp = this.buildBeforeUp
         r.buildBeforePull = this.buildBeforePull


### PR DESCRIPTION
This PR solves #289 by introducing the `nested` method, to get previously created nested settings.

This PR also changes the original `createNested` method to `protected` and renames it (because it is not intended to be called by users), but also introduces a new method with the same signature, to keep backward compatibility.

The issue with the original `createNested` was that it created a new nested settings but it didn't register it (so it wasn't possible to read it later).