### PR TITLE
Add a configuration option to retain containers if ComposeUp fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ dockerCompose {
 
     stopContainers = true // doesn't call `docker-compose down` if set to false - see below the paragraph about reconnecting; default is true
     removeContainers = true // default is true
+    retainContainersOnStartupFailure = false // if set to true, skips running ComposeDownForced task when ComposeUp fails - useful for troubleshooting; default is false
     removeImages = "None" // Other accepted values are: "All" and "Local"
     removeVolumes = true // default is true
     removeOrphans = false // removes containers for services not defined in the Compose file; default is false
@@ -218,3 +219,5 @@ Because you don't want to check-in this change to your VCS, you can take advanta
 * Check [ContainerInfo.groovy](/src/main/groovy/com/avast/gradle/dockercompose/ContainerInfo.groovy) to see what you can know about running containers.
 * You can determine the Docker host in your Gradle build (i.e. `docker-machine start`) and set the `DOCKER_HOST` environment variable for compose to use: `dockerCompose { environment.put 'DOCKER_HOST', '192.168.64.9' }`
 * If the services executed by `docker-compose` are running on a specific host (different than Docker, like in CirceCI 2.0), then `SERVICES_HOST` environment variable can be used. This value will be used as the hostname where the services are expected to be listening.
+* If you need to troubleshoot a failing ComposeUp task, set `retainContainersOnStartupFailure` to prevent containers from begin forcibly deleted. Does not override `removeContainers`, so if you run `ComposeDown`, it will not be affected.
+

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -88,6 +88,7 @@ class ComposeSettings {
 
     boolean stopContainers = true
     boolean removeContainers = true
+    boolean retainContainersOnStartupFailure = false
     RemoveImages removeImages = RemoveImages.None
     boolean removeVolumes = true
     boolean includeDependencies = false

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -91,7 +91,9 @@ class ComposeUp extends DefaultTask {
         }
         catch (Exception e) {
             logger.debug("Failed to start-up Docker containers", e)
-            settings.downForcedTask.get().down()
+            if (!settings.retainContainersOnStartupFailure) {
+                settings.downForcedTask.get().down()
+            }
             throw e
         }
     }

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
@@ -50,6 +50,20 @@ class ComposeExecutorTest extends Specification {
                       - web1
             '''
 
+    @Shared
+    def composeWithFailingContainer = '''
+            version: '3.9'
+            services:
+                fail:
+                    image: nginx:stable
+                    command: bash -c "echo not so stable && exit 1"
+                double_fail:
+                    image: hello-world
+                    depends_on:
+                        fail:
+                            condition: service_completed_successfully
+            '''
+
     @Unroll
     def "getServiceNames calculates service names correctly when includeDependencies is #includeDependencies" () {
         def f = Fixture.custom(composeFile)
@@ -75,5 +89,29 @@ class ComposeExecutorTest extends Specification {
         false               | ["webMaster"]                 | composeV1_webMasterWithDeps
         true                | ["webMaster", "web0", "web1"] | composeV2_webMasterWithDeps
         false               | ["webMaster"]                 | composeV2_webMasterWithDeps
+    }
+
+    def "If composeUp fails, containers should be deleted depending on retainContainersOnStartupFailure setting"() {
+        setup:
+        def f = Fixture.custom(composeWithFailingContainer)
+        f.project.plugins.apply 'java'
+        f.project.dockerCompose.startedServices = ['fail', 'double_fail']
+        f.project.dockerCompose.retainContainersOnStartupFailure = retain
+        f.project.dockerCompose
+        f.project.plugins.apply 'docker-compose'
+
+        when:
+        f.project.tasks.composeUp.up()
+
+        then:
+        thrown(RuntimeException)
+        assert f.project.dockerCompose.composeExecutor.getContainerIds('fail').size() == (retain ? 1 : 0)
+        assert f.project.dockerCompose.composeExecutor.getContainerIds('double_fail').isEmpty()
+
+        cleanup:
+        f.close()
+
+        where:
+        retain << [true, false]
     }
 }

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
@@ -109,6 +109,7 @@ class ComposeExecutorTest extends Specification {
         assert f.project.dockerCompose.composeExecutor.getContainerIds('double_fail').isEmpty()
 
         cleanup:
+        f.project.tasks.composeDownForced.down()
         f.close()
 
         where:


### PR DESCRIPTION
Currently, when a `ComposeUp` task fails to start the services, the whole project will be torn down forcefully by executing the `ComposeDownForced` task. Such behavior leaves limited room for troubleshooting why the services failed to start in the first place.

This PR introduces a new configuration option, `retainContainersOnStartupFailure` that, if set to true, would retain the containers. It is set by default to keep the current default behavior unchanged.