### PR TITLE
chore: classes created via ObjectFactory

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -3,7 +3,10 @@ package com.avast.gradle.dockercompose
 import org.gradle.api.Project
 import org.gradle.util.ConfigureUtil
 
+import javax.inject.Inject
+
 class ComposeExtension extends ComposeSettings {
+    @Inject
     ComposeExtension(Project project) {
         super(project, '', '')
     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/DockerComposePlugin.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/DockerComposePlugin.groovy
@@ -6,6 +6,6 @@ import org.gradle.api.Project
 class DockerComposePlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
-        project.extensions.create('dockerCompose', ComposeExtension, project)
+        project.extensions.create('dockerCompose', ComposeExtension)
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/DockerExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/DockerExecutor.groovy
@@ -1,24 +1,30 @@
 package com.avast.gradle.dockercompose
 
-import org.gradle.api.Project
 import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+import org.gradle.process.ExecOperations
 import org.gradle.process.ExecSpec
 import org.yaml.snakeyaml.Yaml
 
+import javax.inject.Inject
+
 class DockerExecutor {
     private final ComposeSettings settings
-    private final Project project
-    private final Logger logger
+    private final ExecOperations exec
 
-    DockerExecutor(ComposeSettings settings) {
+    private static final Logger logger = Logging.getLogger(DockerExecutor.class);
+
+    @Inject
+    DockerExecutor(ComposeSettings settings, ExecOperations exec) {
         this.settings = settings
-        this.project = settings.project
-        this.logger = settings.project.logger
+        this.exec = exec
     }
 
     String execute(String... args) {
+        def exec = this.exec
+        def settings = this.settings
         new ByteArrayOutputStream().withStream { os ->
-            def er = project.exec { ExecSpec e ->
+            def er = exec.exec { ExecSpec e ->
                 e.environment = settings.environment
                 def finalArgs = [settings.dockerExecutable]
                 finalArgs.addAll(args)


### PR DESCRIPTION
`DockerExecutor` and `ComposeExecutor` instances created via `ObjectFactory`, and doesn't have a dependency on `Project`, thus this reduces list of issues that prevents tasks caching, as reported in #307