### PR TITLE
Support ComposeV2

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeConfigParser.groovy
@@ -17,7 +17,7 @@ class ComposeConfigParser
     {
         Map<String, Object> parsed = new Yaml().load(composeConfigOutput)
         // if there is 'version' on top-level then information about services is in 'services' sub-tree
-        Map<String, Object> services = (parsed.version ? parsed.services : parsed)
+        Map<String, Object> services = (parsed.services ? parsed.services : parsed)
         Map<String, Set<String>> declaredServiceDependencies = services.collectEntries { [(it.key): getDirectServiceDependencies(it.value)] }
         services.keySet().collectEntries { [(it): calculateDependenciesFromGraph(it, declaredServiceDependencies)] }
     }

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -100,7 +100,11 @@ class ComposeExecutor {
     }
 
     Iterable<String> getContainerIds(String serviceName) {
-        execute('ps', '-q', serviceName).readLines()
+        try {
+            execute('ps', '-q', serviceName).readLines()
+        } catch (RuntimeException ignored) {
+            return []
+        }
     }
 
     void captureContainersOutput(Closure<Void> logMethod, String... services) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -100,11 +100,14 @@ class ComposeExecutor {
     }
 
     Iterable<String> getContainerIds(String serviceName) {
-        try {
-            execute('ps', '-q', serviceName).readLines()
-        } catch (RuntimeException ignored) {
-            return []
+        // `docker-compose ps -q serviceName` returns an exit code of 1 when the service
+        // doesn't exist.  To guard against this, check the service list first.
+        def services = execute('ps', '--services').readLines()
+        if (services.contains(serviceName)) {
+            return execute('ps', '-q', serviceName).readLines()
         }
+
+        return []
     }
 
     void captureContainersOutput(Closure<Void> logMethod, String... services) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -291,20 +291,22 @@ abstract class ComposeSettings {
     }
 
     protected Map<String, Object> createEnvironmentVariables(String variableName, ContainerInfo ci) {
+        def serviceName = variableName.replaceAll('-', '_')
         Map<String, Object> environmentVariables = [:]
-        environmentVariables.put("${variableName}_HOST".toString(), ci.host)
-        environmentVariables.put("${variableName}_CONTAINER_HOSTNAME".toString(), ci.containerHostname)
-        ci.tcpPorts.each { environmentVariables.put("${variableName}_TCP_${it.key}".toString(), it.value) }
-        ci.udpPorts.each { environmentVariables.put("${variableName}_UDP_${it.key}".toString(), it.value) }
+        environmentVariables.put("${serviceName}_HOST".toString(), ci.host)
+        environmentVariables.put("${serviceName}_CONTAINER_HOSTNAME".toString(), ci.containerHostname)
+        ci.tcpPorts.each { environmentVariables.put("${serviceName}_TCP_${it.key}".toString(), it.value) }
+        ci.udpPorts.each { environmentVariables.put("${serviceName}_UDP_${it.key}".toString(), it.value) }
         environmentVariables
     }
 
     protected Map<String, Object> createSystemProperties(String variableName, ContainerInfo ci) {
+        def serviceName = variableName.replaceAll('-', '_')
         Map<String, Object> systemProperties = [:]
-        systemProperties.put("${variableName}.host".toString(), ci.host)
-        systemProperties.put("${variableName}.containerHostname".toString(), ci.containerHostname)
-        ci.tcpPorts.each { systemProperties.put("${variableName}.tcp.${it.key}".toString(), it.value) }
-        ci.udpPorts.each { systemProperties.put("${variableName}.udp.${it.key}".toString(), it.value) }
+        systemProperties.put("${serviceName}.host".toString(), ci.host)
+        systemProperties.put("${serviceName}.containerHostname".toString(), ci.containerHostname)
+        ci.tcpPorts.each { systemProperties.put("${serviceName}.tcp.${it.key}".toString(), it.value) }
+        ci.udpPorts.each { systemProperties.put("${serviceName}.udp.${it.key}".toString(), it.value) }
         systemProperties
     }
 

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -159,7 +159,9 @@ class ComposeUp extends DefaultTask {
         logger.info("Will use $host as host of service $serviceName")
         def tcpPorts = settings.dockerExecutor.getTcpPortsMapping(serviceName, inspection, host)
         def udpPorts = settings.dockerExecutor.getUdpPortsMapping(serviceName, inspection, host)
-        String instanceName = inspection.Name.find(/${serviceName}_\d+/) ?: inspection.Name - '/'
+        String instanceName = inspection.Name.find(/${serviceName}_\d+$/) ?:
+                inspection.Name.find(/${serviceName}-\d+$/) ?:
+                inspection.Name - '/'
         new ContainerInfo(
                 instanceName: instanceName,
                 serviceHost: host,

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -159,6 +159,7 @@ class ComposeUp extends DefaultTask {
         logger.info("Will use $host as host of service $serviceName")
         def tcpPorts = settings.dockerExecutor.getTcpPortsMapping(serviceName, inspection, host)
         def udpPorts = settings.dockerExecutor.getUdpPortsMapping(serviceName, inspection, host)
+        // docker-compose v1 uses an underscore as a separator.  v2 uses a hyphen.
         String instanceName = inspection.Name.find(/${serviceName}_\d+$/) ?:
                 inspection.Name.find(/${serviceName}-\d+$/) ?:
                 inspection.Name - '/'

--- a/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
@@ -14,7 +14,7 @@ class CaptureOutputTest extends Specification {
             services:
                 web:
                     image: nginx:stable
-                    command: bash -c "echo -e 'heres some output\\nand some more' && sleep 5 && nginx -g 'daemon off;'"
+                    command: bash -c "echo -e 'here is some output' && echo -e 'and some more' && sleep 5 && nginx -g 'daemon off;'"
                     ports:
                       - 80
         '''
@@ -36,7 +36,9 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        stdout.toString().contains("web_1") || stdout.toString().contains("web-1")
+        stdout.toString().contains("web_1  | here is some output\nweb_1  | and some more") ||
+                (stdout.toString().contains("web-1  | here is some output") &&
+                        stdout.toString().contains("web-1  | and some more"))
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -50,7 +52,9 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        logFile.text.contains("web_1") || logFile.text.contains("web-1")
+        logFile.text.contains("web_1  | here is some output\nweb_1  | and some more") ||
+                (logFile.text.contains("web-1  | here is some output") &&
+                        logFile.text.contains("web-1  | and some more"))
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -64,7 +68,9 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        logFile.text.contains("web_1") || logFile.text.contains("web-1")
+        logFile.text.contains("web_1  | here is some output\nweb_1  | and some more") ||
+                (logFile.text.contains("web-1  | here is some output") &&
+                        logFile.text.contains("web-1  | and some more"))
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -79,7 +85,9 @@ class CaptureOutputTest extends Specification {
         then:
         noExceptionThrown()
         def logFile = logDir.toPath().resolve('web.log').toFile()
-        logFile.text.contains("web_1") || logFile.text.contains("web-1")
+        logFile.text.contains("web_1  | here is some output\nweb_1  | and some more") ||
+                (logFile.text.contains("web-1  | here is some output") &&
+                        logFile.text.contains("web-1  | and some more"))
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()

--- a/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
@@ -10,11 +10,13 @@ import spock.lang.Specification
 class CaptureOutputTest extends Specification {
 
     private String composeFileContent = '''
-            web:
-                image: nginx:stable
-                command: bash -c "echo -e 'heres some output\\nand some more' && sleep 5 && nginx -g 'daemon off;'"
-                ports:
-                  - 80
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
+                    command: bash -c "echo -e 'heres some output\\nand some more' && sleep 5 && nginx -g 'daemon off;'"
+                    ports:
+                      - 80
         '''
 
     def "captures container output to stdout"() {

--- a/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
@@ -36,7 +36,7 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        stdout.toString().contains("web_1  | heres some output\nweb_1  | and some more")
+        stdout.toString().contains("web_1") || stdout.toString().contains("web-1")
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -50,7 +50,7 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        logFile.text.contains("web_1  | heres some output\nweb_1  | and some more")
+        logFile.text.contains("web_1") || logFile.text.contains("web-1")
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -64,7 +64,7 @@ class CaptureOutputTest extends Specification {
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
-        logFile.text.contains("web_1  | heres some output\nweb_1  | and some more")
+        logFile.text.contains("web_1") || logFile.text.contains("web-1")
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()
@@ -79,7 +79,7 @@ class CaptureOutputTest extends Specification {
         then:
         noExceptionThrown()
         def logFile = logDir.toPath().resolve('web.log').toFile()
-        logFile.text.contains("web_1  | heres some output\nweb_1  | and some more")
+        logFile.text.contains("web_1") || logFile.text.contains("web-1")
         cleanup:
         f.project.tasks.composeDown.down()
         f.close()

--- a/src/test/groovy/com/avast/gradle/dockercompose/CustomComposeFilesTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/CustomComposeFilesTest.groovy
@@ -7,15 +7,19 @@ class CustomComposeFilesTest extends Specification {
     def "can specify compose files to use"() {
         def projectDir = File.createTempDir("gradle", "projectDir")
         new File(projectDir, 'original.yml') << '''
-            web:
-                image: nginx:stable
-                ports:
-                  - 80
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
+                    ports:
+                      - 80
         '''
         new File(projectDir, 'override.yml') << '''
-            web:
-                ports:
-                  - 8080
+            version: '2'
+            services:
+                web:
+                    ports:
+                      - 8080
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
@@ -45,17 +49,21 @@ class CustomComposeFilesTest extends Specification {
     def "docker-compose.override.yml file honoured when no files specified"() {
         def projectDir = File.createTempDir("gradle", "projectDir")
         new File(projectDir, 'docker-compose.yml') << '''
-            web:
-                image: nginx:stable
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
         '''
         new File(projectDir, 'docker-compose.override.yml') << '''
-            web:
-                ports:
-                  - 80
-            devweb:
-                image: nginx:stable
-                ports:
-                  - 80
+            version: '2'
+            services:
+                web:
+                    ports:
+                      - 80
+                devweb:
+                    image: nginx:stable
+                    ports:
+                      - 80
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'
@@ -80,22 +88,28 @@ class CustomComposeFilesTest extends Specification {
     def "docker-compose.override.yml file ignored when files are specified"() {
         def projectDir = File.createTempDir("gradle", "projectDir")
         new File(projectDir, 'docker-compose.yml') << '''
-            web:
-                image: nginx:stable
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
         '''
         new File(projectDir, 'docker-compose.override.yml') << '''
-            web:
-                ports:
-                  - 80
-            devweb:
-                image: nginx:stable
-                ports:
-                  - 80
+            version: '2'
+            services:
+                web:
+                    ports:
+                      - 80
+                devweb:
+                    image: nginx:stable
+                    ports:
+                      - 80
         '''
         new File(projectDir, 'docker-compose.prod.yml') << '''
-            web:
-                ports:
-                  - 8080
+            version: '2'
+            services:
+                web:
+                    ports:
+                      - 8080
         '''
         def project = ProjectBuilder.builder().withProjectDir(projectDir).build()
         project.plugins.apply 'docker-compose'

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -276,14 +276,7 @@ class DockerComposePluginTest extends Specification {
             f.project.tasks.composeDown.down()
             f.close()
         where:
-            // test it for both compose file version 1 and 2
             composeFileContent << ['''
-            web:
-                image: nginx:stable
-                ports:
-                  - 80
-                  - 81/udp
-        ''', '''
             version: '2'
             services:
                 web:
@@ -323,10 +316,12 @@ class DockerComposePluginTest extends Specification {
 
     def "docker-compose substitutes environment variables"() {
         def f = Fixture.custom('''
-            web:
-                image: nginx:stable
-                ports:
-                  - $MY_WEB_PORT
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
+                    ports:
+                      - $MY_WEB_PORT
         ''')
         def integrationTestTask = f.project.tasks.create('integrationTest').doLast {
             ContainerInfo webInfo = f.project.dockerCompose.servicesInfos.web.firstContainer
@@ -405,13 +400,15 @@ class DockerComposePluginTest extends Specification {
     @IgnoreIf({ System.getenv('DOCKER_COMPOSE_VERSION') != null && parse(System.getenv('DOCKER_COMPOSE_VERSION')) < parse('1.13.0') })
     def "docker-compose scale to 0 does not cause exceptions because of missing first container"() {
         def f = Fixture.custom('''
-            web:
-                image: nginx:stable
-                ports:
-                  - 80
-            z:
-                image: nginx:stable
-                ports: []
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
+                    ports:
+                      - 80
+                z:
+                    image: nginx:stable
+                    ports: []
         ''')
         f.extension.scale = ['web': 0]
         def integrationTestTask = f.project.tasks.create('integrationTest').doLast {
@@ -449,12 +446,6 @@ class DockerComposePluginTest extends Specification {
         where:
         // test it for both compose file version 1 and 2
         composeFileContent << ['''
-            web:
-                container_name: custom_container_name
-                image: nginx:stable
-                ports:
-                  - 80
-        ''', '''
             version: '2'
             services:
                 web:
@@ -484,25 +475,7 @@ class DockerComposePluginTest extends Specification {
         cleanup:
         f.close()
         where:
-        // test it for both compose file version 1 and 2
         composeFileContent << ['''
-            web0:
-                image: nginx:stable
-                ports:
-                  - 80
-            web1:
-                image: nginx:stable
-                ports:
-                  - 80
-                links:
-                  - web0
-            webMaster:
-                image: nginx:stable
-                ports:
-                  - 80
-                links:
-                  - web1
-        ''', '''
             version: '2'
             services:
                 web0:

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -360,8 +360,8 @@ class DockerComposePluginTest extends Specification {
         def integrationTestTask = f.project.tasks.create('integrationTest').doLast {
             def webInfos = project.dockerCompose.servicesInfos.web.containerInfos
             assert webInfos.size() == 2
-            assert webInfos.containsKey('web_1')
-            assert webInfos.containsKey('web_2')
+            assert webInfos.containsKey('web_1') || webInfos.containsKey('web-1')
+            assert webInfos.containsKey('web_2') || webInfos.containsKey('web-2')
         }
         when:
             f.project.tasks.composeUp.up()

--- a/src/test/groovy/com/avast/gradle/dockercompose/Fixture.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/Fixture.groovy
@@ -10,18 +10,22 @@ class Fixture implements AutoCloseable {
 
     static withNginx() {
         new Fixture('''
-            web:
-                image: nginx:stable
-                command: bash -c "sleep 5 && nginx -g 'daemon off;'"
-                ports:
-                  - 80
+            version: '2'
+            services:
+                web:
+                    image: nginx:stable
+                    command: bash -c "sleep 5 && nginx -g 'daemon off;'"
+                    ports:
+                      - 80
         ''')
     }
 
     static withHelloWorld() {
         new Fixture('''
-            hello:
-                image: hello-world
+            version: '2'
+            services:
+                hello:
+                    image: hello-world
         ''')
     }
 


### PR DESCRIPTION
`docker-compose` version 2 introduces a few subtle changes that the Gradle plugin needs updating to cope with:

The key one (and the one we noticed first) is the container name separator change from `_` to `-`, e.g.: `dc0d8ebebfc1bd2d95a03ae408b9320f_test__fail_1` vs. `8a14f97d108b86c6af4af2a05bff880f_test_-fail-1`).  This stopped the plugin parsing the container names and setting the environment variables `${serviceName}_HOST`, etc.

`docker-compose ps` now exits with code 1 when the container doesn't exist (instead of outputting an empty list.

ComposeV2 removes support for unversioned configuration files.

Tested with `docker-compose` 1.29.2 and 2.2.3 on an Intel Mac.