### PR TITLE
Fix exposed env variables and system properties names

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -291,7 +291,7 @@ abstract class ComposeSettings {
     }
 
     protected Map<String, Object> createEnvironmentVariables(String variableName, ContainerInfo ci) {
-        def serviceName = variableName.replaceAll('-', '_')
+        def serviceName = replaceV2Separator(variableName)
         Map<String, Object> environmentVariables = [:]
         environmentVariables.put("${serviceName}_HOST".toString(), ci.host)
         environmentVariables.put("${serviceName}_CONTAINER_HOSTNAME".toString(), ci.containerHostname)
@@ -301,13 +301,17 @@ abstract class ComposeSettings {
     }
 
     protected Map<String, Object> createSystemProperties(String variableName, ContainerInfo ci) {
-        def serviceName = variableName.replaceAll('-', '_')
+        def serviceName = replaceV2Separator(variableName)
         Map<String, Object> systemProperties = [:]
         systemProperties.put("${serviceName}.host".toString(), ci.host)
         systemProperties.put("${serviceName}.containerHostname".toString(), ci.containerHostname)
         ci.tcpPorts.each { systemProperties.put("${serviceName}.tcp.${it.key}".toString(), it.value) }
         ci.udpPorts.each { systemProperties.put("${serviceName}.udp.${it.key}".toString(), it.value) }
         systemProperties
+    }
+
+    static String replaceV2Separator(String serviceName) {
+        serviceName.replaceAll('-(\\d+)$', '_$1')
     }
 
     boolean removeOrphans() {


### PR DESCRIPTION
If service name has dashes in docker-compose file (for example `web-service`), then plugin will expose env variables and system properties for this service under the name having dashes replaced with underscores (for example `web_service.host`). This is not an expected behaviour and was a breaking change for us while upgrading plugin version to `0.15.0`


