### PR TITLE
Add support for `docker compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ dockerCompose {
     upAdditionalArgs = ['--no-deps']
     downAdditionalArgs = ['--some-switch']
     composeAdditionalArgs = ['--context', 'remote', '--verbose', "--log-level", "DEBUG"] // for adding more [options] in docker-compose [-f <arg>...] [options] [COMMAND] [ARGS...]
+    dockerComposeV2 = false // Use `docker compose` instead of `docker-compose`
 
     waitForTcpPorts = true // turns on/off the waiting for exposed TCP ports opening; default is true
     waitForTcpPortsTimeout = java.time.Duration.ofMinutes(15) // how long to wait until all exposed TCP become open; default is 15 minutes

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -47,7 +47,7 @@ class ComposeExecutor {
                 e.setWorkingDir(settings.dockerComposeWorkingDirectory.get().asFile)
             }
             e.environment = settings.environment.get()
-            def finalArgs = [settings.executable.get()]
+            List<String> finalArgs = new ArrayList<String>(Arrays.asList(settings.executable.get().split(" ")))
             finalArgs.addAll(settings.composeAdditionalArgs.get())
             if (noAnsi) {
                 if (version >= VersionNumber.parse('1.28.0')) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -45,6 +45,7 @@ abstract class ComposeSettings {
     abstract ListProperty<String> getUseComposeFiles()
     abstract ListProperty<String> getStartedServices()
     abstract Property<Boolean> getIncludeDependencies()
+    abstract Property<Boolean> getDockerComposeV2()
     abstract MapProperty<String, Integer> getScale()
 
     abstract ListProperty<String> getBuildAdditionalArgs()
@@ -123,6 +124,7 @@ abstract class ComposeSettings {
         useComposeFiles.empty()
         startedServices.empty()
         includeDependencies.set(false)
+        dockerComposeV2.set(false)
         scale.empty()
 
         buildAdditionalArgs.empty()
@@ -162,10 +164,19 @@ abstract class ComposeSettings {
         if (OperatingSystem.current().isMacOsX()) {
             // Default installation is inaccessible from path, so set sensible
             // defaults for this platform.
-            executable.set('/usr/local/bin/docker-compose')
+
+            if (dockerComposeV2.get()) {
+                executable.set('/usr/local/bin/docker compose')
+            } else {
+                executable.set('/usr/local/bin/docker-compose')
+            }
             dockerExecutable.set('/usr/local/bin/docker')
         } else {
-            executable.set('docker-compose')
+            if (dockerComposeV2.get()) {
+                executable.set('docker compose')
+            } else {
+                executable.set('docker-compose')
+            }
             dockerExecutable.set('docker')
         }
         environment.set(System.getenv())
@@ -195,6 +206,7 @@ abstract class ComposeSettings {
         def r = project.objects.newInstance(ComposeSettings, project, name, this.nestedName)
 
         r.includeDependencies.set(includeDependencies.get())
+        r.dockerComposeV2.set(dockerComposeV2.get())
 
         r.buildAdditionalArgs.set(new ArrayList<String>(this.buildAdditionalArgs.get()))
         r.pullAdditionalArgs.set(new ArrayList<String>(this.pullAdditionalArgs.get()))


### PR DESCRIPTION
Enable using `dockerComposeV2.set(true)`

Should fix https://github.com/avast/gradle-docker-compose-plugin/issues/322, but hasn't been thoroughly tested
