### PR TITLE
Add configuration cache support

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -46,7 +46,7 @@ class ComposeExecutor {
             if (settings.dockerComposeWorkingDirectory.isPresent()) {
                 e.setWorkingDir(settings.dockerComposeWorkingDirectory.get().asFile)
             }
-            e.environment = settings.environment.get()
+            e.environment = System.getenv() + settings.environment.get()
             def finalArgs = [settings.executable.get()]
             finalArgs.addAll(settings.composeAdditionalArgs.get())
             if (noAnsi) {

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -44,7 +44,7 @@ abstract class ComposeExtension extends ComposeSettings {
             taskName = taskName[0].toLowerCase() + taskName.substring(1)
             ComposeSettings s = getOrCreateNested(taskName)
             s.useComposeFiles = [args[0].toString()]
-            project.tasks.findAll { it.name.equalsIgnoreCase(taskName) }.forEach { s.isRequiredBy(it) }
+            tasksConfigurator.setupMissingRequiredBy(taskName, s)
             s
         } else if (args.length == 1 && args[0] instanceof Closure) {
             ComposeSettings s = getOrCreateNested(name)

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -168,7 +168,6 @@ abstract class ComposeSettings {
             executable.set('docker-compose')
             dockerExecutable.set('docker')
         }
-        environment.set(System.getenv())
         dockerComposeStopTimeout.set(Duration.ofSeconds(10))
 
         this.containerLogToDir.set(project.buildDir.toPath().resolve('containers-logs').toFile())

--- a/src/main/groovy/com/avast/gradle/dockercompose/DockerExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/DockerExecutor.groovy
@@ -25,7 +25,7 @@ class DockerExecutor {
         def settings = this.settings
         new ByteArrayOutputStream().withStream { os ->
             def er = exec.exec { ExecSpec e ->
-                e.environment = settings.environment.get()
+                e.environment = System.getenv() + settings.environment.get()
                 def finalArgs = [settings.dockerExecutable.get()]
                 finalArgs.addAll(args)
                 e.commandLine finalArgs

--- a/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
@@ -1,0 +1,144 @@
+package com.avast.gradle.dockercompose
+
+import com.avast.gradle.dockercompose.tasks.*
+import groovy.transform.CompileStatic
+import groovy.transform.PackageScope
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.process.JavaForkOptions
+import org.gradle.process.ProcessForkOptions
+
+@CompileStatic
+class TasksConfigurator {
+    final ComposeSettings composeSettings
+    final Project project
+    final TaskProvider<ComposeUp> upTask
+    final TaskProvider<ComposeDown> downTask
+    final TaskProvider<ComposeDownForced> downForcedTask
+    final TaskProvider<ComposeDownForced> downForcedOnFailureTask
+    final TaskProvider<ComposeBuild> buildTask
+    final TaskProvider<ComposePull> pullTask
+    final TaskProvider<ComposeLogs> logsTask
+    final TaskProvider<ComposePush> pushTask
+
+    TasksConfigurator(ComposeSettings composeSettings, Project project, String name = '') {
+        this.composeSettings = composeSettings
+        this.project = project
+        Provider<ComposeExecutor> composeExecutor = ComposeExecutor.getInstance(project, composeSettings)
+        Provider<ServiceInfoCache> serviceInfoCache = ServiceInfoCache.getInstance(project, composeSettings.nestedName)
+        this.upTask = project.tasks.register(name ? "${name}ComposeUp".toString() : 'composeUp', ComposeUp) {task ->
+            task.stopContainers.set(composeSettings.stopContainers)
+            task.forceRecreate.set(composeSettings.forceRecreate)
+            task.noRecreate.set(composeSettings.noRecreate)
+            task.scale.set(composeSettings.scale)
+            task.upAdditionalArgs.set(composeSettings.upAdditionalArgs)
+            task.startedServices.set(composeSettings.startedServices)
+            task.composeLogToFile.set(composeSettings.composeLogToFile)
+            task.waitForTcpPorts.set(composeSettings.waitForTcpPorts)
+            task.retainContainersOnStartupFailure.set(composeSettings.retainContainersOnStartupFailure)
+            task.captureContainersOutput.set(composeSettings.captureContainersOutput)
+            task.captureContainersOutputToFile.set(composeSettings.captureContainersOutputToFile)
+            task.captureContainersOutputToFiles.set(composeSettings.captureContainersOutputToFiles)
+            task.waitAfterHealthyStateProbeFailure.set(composeSettings.waitAfterHealthyStateProbeFailure)
+            task.checkContainersRunning.set(composeSettings.checkContainersRunning)
+            task.waitForHealthyStateTimeout.set(composeSettings.waitForHealthyStateTimeout)
+            task.tcpPortsToIgnoreWhenWaiting.set(composeSettings.tcpPortsToIgnoreWhenWaiting)
+            task.waitForTcpPortsDisconnectionProbeTimeout.set(composeSettings.waitForTcpPortsDisconnectionProbeTimeout)
+            task.waitForTcpPortsTimeout.set(composeSettings.waitForTcpPortsTimeout)
+            task.waitAfterTcpProbeFailure.set(composeSettings.waitAfterTcpProbeFailure)
+            task.serviceInfoCache.set(serviceInfoCache)
+            task.composeExecutor.set(composeExecutor)
+            task.dependsOn(composeSettings.buildBeforeUp.map { buildBeforeUp ->
+                buildBeforeUp ? [buildTask] : []
+            })
+            task.dockerExecutor = composeSettings.dockerExecutor
+            task.finalizedBy(downForcedOnFailureTask)
+        }
+        this.buildTask = project.tasks.register(name ? "${name}ComposeBuild".toString() : 'composeBuild', ComposeBuild) {task ->
+            task.buildAdditionalArgs.set(composeSettings.buildAdditionalArgs)
+            task.startedServices.set(composeSettings.startedServices)
+            task.composeExecutor.set(composeExecutor)
+        }
+        this.pullTask = project.tasks.register(name ? "${name}ComposePull".toString() : 'composePull', ComposePull) {task ->
+            task.ignorePullFailure.set(composeSettings.ignorePullFailure)
+            task.pullAdditionalArgs.set(composeSettings.pullAdditionalArgs)
+            task.startedServices.set(composeSettings.startedServices)
+            task.composeExecutor.set(composeExecutor)
+            task.dependsOn(composeSettings.buildBeforePull.map { buildBeforePull ->
+                buildBeforePull ? [buildTask] : []
+            })
+        }
+        this.downTask = project.tasks.register(name ? "${name}ComposeDown".toString() : 'composeDown', ComposeDown) {task ->
+            configureDownForcedTask(task, composeExecutor, serviceInfoCache)
+            task.stopContainers.set(composeSettings.stopContainers)
+        }
+        this.downForcedTask = project.tasks.register(name ? "${name}ComposeDownForced".toString() : 'composeDownForced', ComposeDownForced) {task ->
+            configureDownForcedTask(task, composeExecutor, serviceInfoCache)
+        }
+        this.downForcedOnFailureTask = project.tasks.register(name ? "${name}ComposeDownForcedOnFailure".toString() : 'composeDownForcedOnFailure', ComposeDownForced) {task ->
+            configureDownForcedTask(task, composeExecutor, serviceInfoCache)
+            task.onlyIf { task.serviceInfoCache.get().startupFailed }
+        }
+        this.logsTask = project.tasks.register(name ? "${name}ComposeLogs".toString() : 'composeLogs', ComposeLogs) {task ->
+            task.containerLogToDir.set(composeSettings.containerLogToDir)
+            task.composeExecutor.set(composeExecutor)
+        }
+        this.pushTask = project.tasks.register(name ? "${name}ComposePush".toString() : 'composePush', ComposePush) {task ->
+            task.ignorePushFailure.set(composeSettings.ignorePushFailure)
+            task.pushServices.set(composeSettings.pushServices)
+            task.composeExecutor.set(composeExecutor)
+        }
+    }
+
+    private void configureDownForcedTask(
+            ComposeDownForced task,
+            Provider<ComposeExecutor> composeExecutor,
+            Provider<ServiceInfoCache> serviceInfoCache
+    ) {
+        task.dockerComposeStopTimeout.set(composeSettings.dockerComposeStopTimeout)
+        task.removeContainers.set(composeSettings.removeContainers)
+        task.startedServices.set(composeSettings.startedServices)
+        task.removeVolumes.set(composeSettings.removeVolumes)
+        task.removeImages.set(composeSettings.removeImages)
+        task.downAdditionalArgs.set(composeSettings.downAdditionalArgs)
+        task.composeLogToFile.set(composeSettings.composeLogToFile)
+        task.nestedName.set(composeSettings.nestedName)
+        task.composeExecutor.set(composeExecutor)
+        task.serviceInfoCache.set(serviceInfoCache)
+    }
+
+    @PackageScope
+    void isRequiredByCore(Task task, boolean fromConfigure) {
+        task.dependsOn upTask
+        task.finalizedBy downTask
+        project.tasks.findAll { Task.class.isAssignableFrom(it.class) && ((Task) it).name.toLowerCase().contains('classes') }
+                .each { classesTask ->
+                    if (fromConfigure) {
+                        upTask.get().shouldRunAfter classesTask
+                    } else {
+                        upTask.configure { it.shouldRunAfter classesTask }
+                    }
+                }
+        if (task instanceof ProcessForkOptions) task.doFirst { composeSettings.exposeAsEnvironment(task as ProcessForkOptions) }
+        if (task instanceof JavaForkOptions) task.doFirst { composeSettings.exposeAsSystemProperties(task as JavaForkOptions) }
+    }
+
+    @PackageScope
+    Map<String, ServiceInfo> getServicesInfos() {
+        upTask.get().servicesInfos
+    }
+
+    @PackageScope
+    void setupMissingRequiredBy(String taskName, ComposeSettings settings) {
+        project.tasks
+                .findAll { Task task -> task.name.equalsIgnoreCase(taskName) }
+                .forEach { Task task -> settings.isRequiredBy(task) }
+    }
+
+    @PackageScope
+    ComposeSettings newComposeSettings(String name, String nestedName) {
+        return project.objects.newInstance(ComposeSettings, project, name, nestedName)
+    }
+}

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeBuild.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeBuild.groovy
@@ -1,16 +1,25 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ComposeExecutor
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ComposeBuild extends DefaultTask {
+abstract class ComposeBuild extends DefaultTask {
 
     @Internal
-    ComposeSettings settings
+    abstract ListProperty<String> getBuildAdditionalArgs()
+
+    @Internal
+    abstract ListProperty<String> getStartedServices()
+
+    @Internal
+    abstract Property<ComposeExecutor> getComposeExecutor()
 
     ComposeBuild() {
         group = 'docker'
@@ -20,8 +29,8 @@ class ComposeBuild extends DefaultTask {
     @TaskAction
     void build() {
         String[] args = ['build']
-        args += (List<String>)settings.buildAdditionalArgs.get()
-        args += (List<String>)settings.startedServices.get()
-        settings.composeExecutor.execute(args)
+        args += (List<String>) buildAdditionalArgs.get()
+        args += (List<String>) startedServices.get()
+        composeExecutor.get().execute(args)
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDown.groovy
@@ -1,10 +1,15 @@
 package com.avast.gradle.dockercompose.tasks
 
 import groovy.transform.CompileStatic
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ComposeDown extends ComposeDownForced {
+abstract class ComposeDown extends ComposeDownForced {
+    @Internal
+    abstract Property<Boolean> getStopContainers()
+
     ComposeDown() {
         group = 'docker'
         description = 'Stops and removes containers of docker-compose project (only if stopContainers is set to true)'
@@ -12,7 +17,7 @@ class ComposeDown extends ComposeDownForced {
 
     @TaskAction
     void down() {
-        if (settings.stopContainers.get()) {
+        if (stopContainers.get()) {
             super.down()
         } else {
             logger.lifecycle('You\'re trying to stop the containers, but stopContainers is set to false. Please use composeDownForced task instead.')

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeDownForced.groovy
@@ -1,15 +1,49 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ComposeExecutor
 import com.avast.gradle.dockercompose.RemoveImages
+import com.avast.gradle.dockercompose.ServiceInfoCache
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 import org.gradle.util.VersionNumber
 
-class ComposeDownForced extends DefaultTask {
+import java.time.Duration
+
+abstract class ComposeDownForced extends DefaultTask {
+
     @Internal
-    ComposeSettings settings
+    abstract Property<Duration> getDockerComposeStopTimeout()
+
+    @Internal
+    abstract Property<Boolean> getRemoveContainers()
+
+    @Internal
+    abstract ListProperty<String> getStartedServices()
+
+    @Internal
+    abstract Property<Boolean> getRemoveVolumes()
+
+    @Internal
+    abstract Property<RemoveImages> getRemoveImages()
+
+    @Internal
+    abstract ListProperty<String> getDownAdditionalArgs()
+
+    @Internal
+    abstract RegularFileProperty getComposeLogToFile()
+    
+    @Internal
+    abstract Property<String> getNestedName()
+
+    @Internal
+    abstract Property<ComposeExecutor> getComposeExecutor()
+
+    @Internal
+    abstract Property<ServiceInfoCache> getServiceInfoCache()
 
     ComposeDownForced() {
         group = 'docker'
@@ -18,49 +52,49 @@ class ComposeDownForced extends DefaultTask {
 
     @TaskAction
     void down() {
-        def servicesToStop = settings.composeExecutor.serviceNames
-        settings.serviceInfoCache.clear()
-        settings.composeExecutor.execute(*['stop', '--timeout', settings.dockerComposeStopTimeout.get().getSeconds().toString(), *servicesToStop])
-        if (settings.removeContainers.get()) {
-            if (settings.composeExecutor.version >= VersionNumber.parse('1.6.0')) {
+        def servicesToStop = composeExecutor.get().serviceNames
+        serviceInfoCache.get().clear()
+        composeExecutor.get().execute(*['stop', '--timeout', dockerComposeStopTimeout.get().getSeconds().toString(), *servicesToStop])
+        if (removeContainers.get()) {
+            if (composeExecutor.get().version >= VersionNumber.parse('1.6.0')) {
                 String[] args = []
-                if (!settings.startedServices.get().empty) {
+                if (!startedServices.get().empty) {
                     args += ['rm', '-f']
-                    if (settings.removeVolumes.get()) {
+                    if (removeVolumes.get()) {
                         args += ['-v']
                     }
                     args += servicesToStop
                 } else {
                     args += ['down']
-                    switch (settings.removeImages.get()) {
+                    switch (removeImages.get()) {
                         case RemoveImages.All:
                         case RemoveImages.Local:
-                            args += ['--rmi', "${settings.removeImages.get()}".toLowerCase()]
+                            args += ['--rmi', "${removeImages.get()}".toLowerCase()]
                             break
                         default:
                             break
                     }
-                    if (settings.removeVolumes.get()) {
+                    if (removeVolumes.get()) {
                         args += ['--volumes']
                     }
-                    if (settings.removeOrphans()) {
+                    if (composeExecutor.get().shouldRemoveOrphans()) {
                         args += '--remove-orphans'
                     }
-                    args += settings.downAdditionalArgs.get()
+                    args += downAdditionalArgs.get()
                 }
                 def composeLog = null
-                if(settings.composeLogToFile.isPresent()) {
-                  File logFile = settings.composeLogToFile.get().asFile
+                if (composeLogToFile.isPresent()) {
+                  File logFile = composeLogToFile.get().asFile
                   logger.debug "Logging docker-compose down to: $logFile"
                   logFile.parentFile.mkdirs()
                   composeLog = new FileOutputStream(logFile, true)
                 }
-                settings.composeExecutor.executeWithCustomOutputWithExitValue(composeLog, args)
+                composeExecutor.get().executeWithCustomOutputWithExitValue(composeLog, args)
             } else {
-                if (!settings.startedServices.get().empty) {
-                    settings.composeExecutor.execute(*['rm', '-f', *servicesToStop])
+                if (!startedServices.get().empty) {
+                    composeExecutor.get().execute(*['rm', '-f', *servicesToStop])
                 } else {
-                    settings.composeExecutor.execute('rm', '-f')
+                    composeExecutor.get().execute('rm', '-f')
                 }
             }
         }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeLogs.groovy
@@ -1,16 +1,22 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ComposeExecutor
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ComposeLogs extends DefaultTask {
+abstract class ComposeLogs extends DefaultTask {
 
   @Internal
-  ComposeSettings settings
+  abstract DirectoryProperty getContainerLogToDir()
+
+  @Internal
+  abstract Property<ComposeExecutor> getComposeExecutor()
 
   ComposeLogs() {
     group = 'docker'
@@ -19,13 +25,13 @@ class ComposeLogs extends DefaultTask {
 
   @TaskAction
   void logs() {
-    settings.composeExecutor.serviceNames.each { service ->
+    composeExecutor.get().serviceNames.each { service ->
       println "Extracting container log from service '${service}'"
-      File logFile = settings.containerLogToDir.get().asFile
+      File logFile = containerLogToDir.get().asFile
       logFile.mkdirs()
       def logStream = new FileOutputStream("${logFile.absolutePath}/${service}.log")
       String[] args = ['logs', '-t', service]
-      settings.composeExecutor.executeWithCustomOutputWithExitValue(logStream, args)
+      composeExecutor.get().executeWithCustomOutputWithExitValue(logStream, args)
     }
   }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePull.groovy
@@ -1,16 +1,28 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ComposeExecutor
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ComposePull extends DefaultTask {
+abstract class ComposePull extends DefaultTask {
 
     @Internal
-    ComposeSettings settings
+    abstract Property<Boolean> getIgnorePullFailure()
+
+    @Internal
+    abstract ListProperty<String> getPullAdditionalArgs()
+
+    @Internal
+    abstract ListProperty<String> getStartedServices()
+
+    @Internal
+    abstract Property<ComposeExecutor> getComposeExecutor()
 
     ComposePull() {
         group = 'docker'
@@ -19,15 +31,12 @@ class ComposePull extends DefaultTask {
 
     @TaskAction
     void pull() {
-        if (settings.buildBeforePull.get()) {
-            settings.buildTask.get().build()
-        }
         String[] args = ['pull']
-        if (settings.ignorePullFailure.get()) {
+        if (ignorePullFailure.get()) {
             args += '--ignore-pull-failures'
         }
-        args += (List<String>)settings.pullAdditionalArgs.get()
-        args += (List<String>)settings.startedServices.get()
-        settings.composeExecutor.execute(args)
+        args += (List<String>) pullAdditionalArgs.get()
+        args += (List<String>) startedServices.get()
+        composeExecutor.get().execute(args)
     }
 }

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePush.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposePush.groovy
@@ -1,16 +1,25 @@
 package com.avast.gradle.dockercompose.tasks
 
-import com.avast.gradle.dockercompose.ComposeSettings
+import com.avast.gradle.dockercompose.ComposeExecutor
 import groovy.transform.CompileStatic
 import org.gradle.api.DefaultTask
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
 
 @CompileStatic
-class ComposePush extends DefaultTask {
+abstract class ComposePush extends DefaultTask {
 
     @Internal
-    ComposeSettings settings
+    abstract Property<Boolean> getIgnorePushFailure()
+
+    @Internal
+    abstract ListProperty<String> getPushServices()
+
+    @Internal
+    abstract Property<ComposeExecutor> getComposeExecutor()
 
     ComposePush() {
         group = 'docker'
@@ -20,10 +29,10 @@ class ComposePush extends DefaultTask {
     @TaskAction
     void push() {
         String[] args = ['push']
-        if (settings.ignorePushFailure.get()) {
+        if (ignorePushFailure.get()) {
             args += '--ignore-push-failures'
         }
-        args += (List<String>)settings.pushServices.get()
-        settings.composeExecutor.execute(args)
+        args += (List<String>) pushServices.get()
+        composeExecutor.get().execute(args)
     }
 }

--- a/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/CaptureOutputTest.groovy
@@ -33,6 +33,7 @@ class CaptureOutputTest extends Specification {
 
         when:
         f.extension.captureContainersOutput = true
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
@@ -49,6 +50,7 @@ class CaptureOutputTest extends Specification {
         def logFile = new File(f.project.projectDir, "web.log")
         when:
         f.extension.captureContainersOutputToFile = logFile
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
@@ -65,6 +67,7 @@ class CaptureOutputTest extends Specification {
         def logFile = new File(f.project.projectDir, "web.log")
         when:
         f.extension.captureContainersOutputToFile = f.project.file("${logFile.absolutePath}")
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
@@ -81,6 +84,7 @@ class CaptureOutputTest extends Specification {
         def logDir = new File(f.project.projectDir, "logDir")
         when:
         f.extension.captureContainersOutputToFiles = logDir
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         then:
         noExceptionThrown()
@@ -98,6 +102,7 @@ class CaptureOutputTest extends Specification {
         def logFile = new File(f.project.projectDir, "compose.log")
         when:
         f.extension.composeLogToFile = f.project.file("${logFile.absolutePath}")
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         then:
         f.project.tasks.composeDown.down()

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
@@ -37,7 +37,7 @@ class ComposeExecutorTest extends Specification {
         f.project.plugins.apply 'docker-compose'
 
         when:
-        def configuredServices = f.project.dockerCompose.composeExecutor.getServiceNames()
+        def configuredServices = ComposeExecutor.getInstance(f.project, f.project.dockerCompose).get().getServiceNames()
 
         then:
         configuredServices.containsAll(expectedServices)

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerExecutorTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerExecutorTest.groovy
@@ -16,6 +16,7 @@ class DockerExecutorTest extends Specification {
     def "reads network gateway"() {
         def f = Fixture.withNginx()
         when:
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         ServiceInfo serviceInfo = f.project.tasks.composeUp.servicesInfos.find().value
         String networkName = serviceInfo.firstContainer.inspection.NetworkSettings.Networks.find().key
@@ -30,6 +31,7 @@ class DockerExecutorTest extends Specification {
 
     def "reads container logs"() {
         def f = Fixture.withHelloWorld()
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         String containerId = f.extension.servicesInfos.hello.firstContainer.containerId
         when:

--- a/src/test/groovy/com/avast/gradle/dockercompose/ServiceInfoCacheTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ServiceInfoCacheTest.groovy
@@ -1,14 +1,15 @@
 package com.avast.gradle.dockercompose
 
-import com.avast.gradle.dockercompose.tasks.ServiceInfoCache
+
 import spock.lang.Specification
 
 class ServiceInfoCacheTest extends Specification {
 
     def "gets what was set"() {
         def f = Fixture.withNginx()
-        def target = new ServiceInfoCache(f.project.tasks.composeUp.settings)
+        def target = ServiceInfoCache.getInstance(f.project, f.project.tasks.composeDown.nestedName.get()).get()
         when:
+        f.project.tasks.composeBuild.build()
         f.project.tasks.composeUp.up()
         def original = f.project.tasks.composeUp.servicesInfos
         target.set(original, 'state')


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/configuration_cache.html

Mostly the PR is about more fine-grained property references. Cross-task references are reworked into task dependencies. `ServiceInfoCache` and `ComposeExecutor` are reworked into [build services](https://docs.gradle.org/current/userguide/build_services.html). There may be instantiated too many build services with the current implementation, but it's still a good starter for later optimizations. I guess `DockerExecutor` should be reworked in some way too, at least it would be great to remove back-reference to `ComposeSettings`

I'm open to any feedback. I'm not very familiar with the plugin, so some changes may be considered as not efficient or incorrect.

`composeBuild` manual execution is added to many of tests because it's impossible now to execute task and it's dependencies just like it was a regular Gradle build. Test infrastructure changes (moving to Gradle TestKit) are needed for creating more tests, including configuration cache tests, but that should be the point of another issue/MR, and I can't invest into it now.

Fixes #307 