### PR TITLE
Fixed `isRequiredBy` breaking configuration avoidance

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
@@ -114,14 +114,11 @@ class TasksConfigurator {
     void isRequiredByCore(Task task, boolean fromConfigure) {
         task.dependsOn upTask
         task.finalizedBy downTask
-        project.tasks.findAll { Task.class.isAssignableFrom(it.class) && ((Task) it).name.toLowerCase().contains('classes') }
-                .each { classesTask ->
-                    if (fromConfigure) {
-                        upTask.get().shouldRunAfter classesTask
-                    } else {
-                        upTask.configure { it.shouldRunAfter classesTask }
-                    }
-                }
+        if (fromConfigure) {
+            upTask.get().shouldRunAfter task.taskDependencies
+        } else {
+            upTask.configure { it.shouldRunAfter task.taskDependencies }
+        }
         if (task instanceof ProcessForkOptions) task.doFirst { composeSettings.exposeAsEnvironment(task as ProcessForkOptions) }
         if (task instanceof JavaForkOptions) task.doFirst { composeSettings.exposeAsSystemProperties(task as JavaForkOptions) }
     }

--- a/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/DockerComposePluginTest.groovy
@@ -198,7 +198,7 @@ class DockerComposePluginTest extends Specification {
         when:
             project.dockerCompose.isRequiredBy(project.tasks.test)
         then:
-            project.tasks.composeUp.shouldRunAfter.mutableValues.any { it == project.tasks.testClasses }
+            project.tasks.composeUp.shouldRunAfter.getDependencies(null).any { it == project.tasks.testClasses }
             noExceptionThrown()
     }
 


### PR DESCRIPTION
FIxes https://github.com/avast/gradle-docker-compose-plugin/fork by avoid explicit references to `classes` tasks by replacing it with `shouldRunAfter task.taskDependencies`.
