### PR TITLE
Add useDockerComposeV2 property

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ dockerCompose {
     projectNamePrefix = 'my_prefix_' // allow to set custom prefix of docker-compose project name, the final project name has nested configuration name appended
     executable = '/path/to/docker-compose' // allow to set the path of the docker-compose executable (useful if not present in PATH)
     dockerExecutable = '/path/to/docker' // allow to set the path of the docker executable (useful if not present in PATH)
+    useDockerComposeV2 = true // Use Docker Compose V2 instead of Docker Compose V1. All invocations will be done using `docker compose` instead of `docker-compose`.
     dockerComposeWorkingDirectory = project.file('/path/where/docker-compose/is/invoked/from')
     dockerComposeStopTimeout = java.time.Duration.ofSeconds(20) // time before docker-compose sends SIGTERM to the running containers after the composeDown task has been started
     environment.put 'BACKEND_ADDRESS', '192.168.1.100' // environment variables to be used when calling 'docker-compose', e.g. for substitution in compose file

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -82,6 +82,7 @@ abstract class ComposeSettings {
 
     abstract Property<String> getExecutable()
     abstract Property<String> getDockerExecutable()
+    abstract Property<Boolean> getUseDockerComposeV2()
     abstract MapProperty<String, Object> getEnvironment()
 
     abstract DirectoryProperty getDockerComposeWorkingDirectory()
@@ -147,6 +148,7 @@ abstract class ComposeSettings {
 
         executable.set('docker-compose')
         dockerExecutable.set('docker')
+        useDockerComposeV2.set(false)
 
         dockerComposeStopTimeout.set(Duration.ofSeconds(10))
 
@@ -203,6 +205,7 @@ abstract class ComposeSettings {
 
         r.executable.set(this.executable.get())
         r.dockerExecutable.set(this.dockerExecutable.get())
+        r.useDockerComposeV2.set(this.useDockerComposeV2.get())
         r.environment.set(new HashMap<String, Object>(this.environment.get()))
 
         r.dockerComposeWorkingDirectory.set(this.dockerComposeWorkingDirectory.getOrNull())

--- a/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
+++ b/src/test/groovy/com/avast/gradle/dockercompose/ComposeExecutorTest.groovy
@@ -51,4 +51,32 @@ class ComposeExecutorTest extends Specification {
         true                | ["webMaster", "web0", "web1"]
         false               | ["webMaster"]
     }
+
+    @Unroll
+    def "getDockerComposeBinaryArgs returns correct values when useDockerComposeV2 is #useDockerComposeV2" () {
+        def f = Fixture.withHelloWorld()
+        f.project.plugins.apply 'java'
+
+        if(useDockerComposeV2 != null) {
+            f.project.dockerCompose.useDockerComposeV2 = useDockerComposeV2
+        }
+
+        f.project.plugins.apply 'docker-compose'
+
+        when:
+        def actual = ComposeExecutor.getInstance(f.project, f.project.dockerCompose).get().getDockerComposeBinaryArgs()
+
+        then:
+        expectedDockerComposeBinaryArgs.size() == actual.size()
+        actual.containsAll(expectedDockerComposeBinaryArgs)
+
+        cleanup:
+        f.close()
+
+        where:
+        useDockerComposeV2 | expectedDockerComposeBinaryArgs
+        true               | ["docker", "compose"]
+        false              | ["docker-compose"]
+        null               | ["docker-compose"]
+    }
 }


### PR DESCRIPTION
# Overview
As has been discussed in #322, #401, and [this PR](https://github.com/avast/gradle-docker-compose-plugin/pull/348), Docker Compose V1 has reached its deprecation date and is no longer supported. While there are several workarounds (including one provided by Docker), these workarounds do not work for everyone and are not desirable in all cases. To this end, this PR adds the ability for `ComposeExecutor` to be configured to run using `docker compose` instead of `docker-compose`.

Additionally, this PR had the following goals:

- Provide a clear and easy way for consumers to opt into using Compose V2
- Make sure Compose V1 is enabled by default
- Make sure the changes did not break any existing APIs
- Make sure the functionality is properly tested
- Make sure the new option is properly documented

# Usage

To use Compose V2, all the user needs to do is add the `useDockerComposeV2` property to the `dockerCompose` section of their `build.gradle` file:

```groovy
dockerCompose {
  useDockerComposeV2 = true
}
```

# Verification

In addition to the unit test added in this PR, the code changes proposed here have been tested and verified to work in a real-world project before the PR was submitted.

### Test Procedure

The following are the steps I used to test these changes in a real-world project:

- Build and publish the plugin to maven local using the following command:

```console
# Signing tasks are excluded for local development purposes
$ ./gradlew clean publishToMavenLocal \
  --exclude-task signDockerComposePluginPluginMarkerMavenPublication \
  --exclude-task signPluginMavenPublication \
  -Pversion=0.16.13-SNAPSHOT
```

- Consume the snapshot version from the local maven repository within  a real-world project:

```toml
[plugins]
avast-docker-compose = { id = "com.avast.gradle.docker-compose", version = "0.16.13-SNAPSHOT" }
```

> **Note:** In my case, I had to add the following lines to the top of my project's `settings.gradle` file so that the project would pick up the plugin from the local maven repository:
>
> ```groovy
> pluginManagement {
>     repositories {
>         mavenLocal()
>         gradlePluginPortal()
>     }
> }
> ```

- Run `./gradlew clean composeUp` and `./gradlew clean composeDown`

### Test Results

Running the test version of the plugin without the `useDockerComposeV2` property set resulted in the following console output. It can plainly be seen that the plugin is using Compose V1 to stand up the stack by the presence of the `WARNING` lines.

![use-docker-compose-v2-not-specified](https://github.com/avast/gradle-docker-compose-plugin/assets/108018290/6602e5e1-9b7b-4f96-a409-2b8b8bdf5cb4)

Running the test version of the plugin with `useDockerComposeV2 = false` resulted in the following console output. Once again, it's clear that the plugin is using Compose V1.

![use-docker-compose-v2-set-to-false](https://github.com/avast/gradle-docker-compose-plugin/assets/108018290/ce20098e-2307-4480-bea5-0920914b99a3)

Running the test version of the plugin with `useDockerComposeV2 = true` resulted in the following console output. In this case, it's clear the plugin was using Compose V2 because the `WARNING` lines are no longer present.

![use-docker-compose-v2-set-to-true](https://github.com/avast/gradle-docker-compose-plugin/assets/108018290/e1a1084e-0ac5-4e2c-bdbe-a7e4cbe18a0e)

These tests were performed on a MacBook Pro M1 Max running OSX 13.4.1 (Ventura), using gradle 7.5.1 and Java 17 (Amazon Corretto 17.0.8).