### PR TITLE
Use gradle 8.2.1 + JDK 17, fix deprecation warning, fixes #409

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,7 @@
+import org.gradle.api.JavaVersion
+
 plugins {
+    id 'base'
     id 'signing'
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'com.gradle.plugin-publish' version '1.2.0'
@@ -9,11 +12,11 @@ apply plugin: 'java'
 apply plugin: 'java-library'
 apply plugin: 'maven-publish'
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-
-group = 'com.avast.gradle'
-archivesBaseName = 'gradle-docker-compose-plugin'
-version = version == 'unspecified' ? 'DEVELOPER-SNAPSHOT' : version
+base {
+    group = 'com.avast.gradle'
+    archivesName = 'gradle-docker-compose-plugin'
+    version = version == 'unspecified' ? 'DEVELOPER-SNAPSHOT' : version
+}
 
 repositories {
     mavenCentral()
@@ -35,6 +38,7 @@ test {
 }
 
 java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
     withJavadocJar()
     withSourcesJar()
 }
@@ -87,19 +91,18 @@ nexusPublishing {
 
 project.ext.set('gradle.publish.key', System.getenv('GRADLE_PORTAL_KEY'))
 project.ext.set('gradle.publish.secret', System.getenv('GRADLE_PORTAL_SECRET'))
-pluginBundle {
-    website = 'https://github.com/avast/gradle-docker-compose-plugin'
-    vcsUrl = 'https://github.com/avast/gradle-docker-compose-plugin'
-    tags = ['docker', 'docker-compose']
-}
 
 gradlePlugin {
+    website = 'https://github.com/avast/gradle-docker-compose-plugin'
+    vcsUrl = 'https://github.com/avast/gradle-docker-compose-plugin'
+
     plugins {
         dockerComposePlugin {
             id = 'com.avast.gradle.docker-compose'
             displayName = 'Gradle Docker Compose plugin'
             description = 'Simplifies usage of Docker Compose for integration testing in Gradle environment.'
             implementationClass = 'com.avast.gradle.dockercompose.DockerComposePlugin'
+            tags.set(['docker', 'docker-compose'])
         }
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExtension.groovy
@@ -1,7 +1,6 @@
 package com.avast.gradle.dockercompose
 
 import org.gradle.api.Project
-import org.gradle.util.ConfigureUtil
 
 import javax.inject.Inject
 
@@ -48,8 +47,10 @@ abstract class ComposeExtension extends ComposeSettings {
             s
         } else if (args.length == 1 && args[0] instanceof Closure) {
             ComposeSettings s = getOrCreateNested(name)
-            ConfigureUtil.configure(args[0] as Closure, s)
-            s
+            Closure<?> closure = (Closure<?>) args[0]
+            closure.setResolveStrategy(Closure.DELEGATE_FIRST)
+            closure.setDelegate(s)
+            closure.call(s)
         } else {
             getOrCreateNested(name)
         }


### PR DESCRIPTION
That fixes the warning for me and I needed some more (small) changes to get it working at all with Gradle 8.2.1 API.
Don't know for 100% if that is the way it should be done, but at least Spring did something similar here:

https://github.com/spring-projects/spring-boot/commit/0f52bbc5607ad91fcd3fa2791b2130c5c0d4ee96

L263+

My project still works with that modified PR - but take this PR with caution.