### PR TITLE
fix: Compose 2.21.0 returns newline-separated JSONs instead of single JSON array

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfoCache.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfoCache.groovy
@@ -49,6 +49,7 @@ abstract class ServiceInfoCache implements BuildService<Parameters> {
             } else {
                 logger.lifecycle("Current and cached states are different, cannot use the cached service infos.")
                 logger.info("Cached state:\n$cachedState\nCurrent state:\n$currentState")
+                System.err.println("Cached state:\n$cachedState\nCurrent state:\n$currentState")
             }
         }
         return null

--- a/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfoCache.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ServiceInfoCache.groovy
@@ -49,7 +49,6 @@ abstract class ServiceInfoCache implements BuildService<Parameters> {
             } else {
                 logger.lifecycle("Current and cached states are different, cannot use the cached service infos.")
                 logger.info("Cached state:\n$cachedState\nCurrent state:\n$currentState")
-                System.err.println("Cached state:\n$cachedState\nCurrent state:\n$currentState")
             }
         }
         return null

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -216,16 +216,17 @@ abstract class ComposeUp extends DefaultTask {
         System.err.println(processesAsString)
         try {
             // Since Docker Compose 2.21.0, the output is not one JSON array but newline-separated JSONs.
-            Object[] processes
+            Map<String, Object>[] processes
             if (processesAsString.startsWith('[')) {
                 processes = new JsonSlurper().parseText(processesAsString)
             } else {
                 System.err.println("Splitted: ${processesAsString.split('\\R')}")
                 processes = processesAsString.split('\\R').collect { new JsonSlurper().parseText(it) }
             }
-            // Status field contains something like "Up 8 seconds", so we have to strip the duration.
+            // Status and RunningFor fields contains something like "Up 8 seconds", so we have to strip the duration.
             List<Object> transformed = processes.collect {
-                if (it.Status.startsWith('Up ')) it.Status = 'Up'
+                if (it.containsKey('Status') && it.Status.startsWith('Up ')) it.Status = 'Up'
+                it.remove('RunningFor')
                 it
             }
             processesState = transformed.join('\t')

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -213,14 +213,12 @@ abstract class ComposeUp extends DefaultTask {
     protected def getStateForCache() {
         String processesAsString = composeExecutor.get().execute('ps', '--format', 'json')
         String processesState = processesAsString
-        System.err.println(processesAsString)
         try {
             // Since Docker Compose 2.21.0, the output is not one JSON array but newline-separated JSONs.
             Map<String, Object>[] processes
             if (processesAsString.startsWith('[')) {
                 processes = new JsonSlurper().parseText(processesAsString)
             } else {
-                System.err.println("Splitted: ${processesAsString.split('\\R')}")
                 processes = processesAsString.split('\\R').collect { new JsonSlurper().parseText(it) }
             }
             List<Object> transformed = processes.collect {
@@ -232,8 +230,6 @@ abstract class ComposeUp extends DefaultTask {
             }
             processesState = transformed.join('\t')
         } catch (Exception e) {
-            System.err.println(e)
-            e.printStackTrace(System.err)
             logger.warn("Cannot process JSON returned from 'docker compose ps --format json'", e)
         }
         processesState + composeExecutor.get().execute('config') + startedServices.get().join(',')

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -223,10 +223,11 @@ abstract class ComposeUp extends DefaultTask {
                 System.err.println("Splitted: ${processesAsString.split('\\R')}")
                 processes = processesAsString.split('\\R').collect { new JsonSlurper().parseText(it) }
             }
-            // Status and RunningFor fields contains something like "Up 8 seconds", so we have to strip the duration.
             List<Object> transformed = processes.collect {
+                // Status field contains something like "Up 8 seconds", so we have to strip the duration.
                 if (it.containsKey('Status') && it.Status.startsWith('Up ')) it.Status = 'Up'
-                it.remove('RunningFor')
+                it.remove('RunningFor') // It also contains a duration information.
+                it.remove('Labels') // The order of labels is not stable.
                 it
             }
             processesState = transformed.join('\t')

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -213,14 +213,14 @@ abstract class ComposeUp extends DefaultTask {
     protected def getStateForCache() {
         String processesAsString = composeExecutor.get().execute('ps', '--format', 'json')
         String processesState = processesAsString
-        logger.error(processesAsString)
+        System.err.println(processesAsString)
         try {
             // Since Docker Compose 2.21.0, the output is not one JSON array but newline-separated JSONs.
             Object[] processes
             if (processesAsString.startsWith('[')) {
                 processes = new JsonSlurper().parseText(processesAsString)
             } else {
-                logger.error("Splitted: ${processesAsString.split('\\R')}")
+                System.err.println("Splitted: ${processesAsString.split('\\R')}")
                 processes = processesAsString.split('\\R').collect { new JsonSlurper().parseText(it) }
             }
             // Status field contains something like "Up 8 seconds", so we have to strip the duration.

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -232,6 +232,7 @@ abstract class ComposeUp extends DefaultTask {
             processesState = transformed.join('\t')
         } catch (Exception e) {
             System.err.println(e)
+            e.printStackTrace(System.err)
             logger.warn("Cannot process JSON returned from 'docker compose ps --format json'", e)
         }
         processesState + composeExecutor.get().execute('config') + startedServices.get().join(',')

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -213,12 +213,14 @@ abstract class ComposeUp extends DefaultTask {
     protected def getStateForCache() {
         String processesAsString = composeExecutor.get().execute('ps', '--format', 'json')
         String processesState = processesAsString
+        logger.error(processesAsString)
         try {
             // Since Docker Compose 2.21.0, the output is not one JSON array but newline-separated JSONs.
             Object[] processes
             if (processesAsString.startsWith('[')) {
                 processes = new JsonSlurper().parseText(processesAsString)
             } else {
+                logger.error("Splitted: ${processesAsString.split('\\R')}")
                 processes = processesAsString.split('\\R').collect { new JsonSlurper().parseText(it) }
             }
             // Status field contains something like "Up 8 seconds", so we have to strip the duration.

--- a/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/tasks/ComposeUp.groovy
@@ -230,6 +230,7 @@ abstract class ComposeUp extends DefaultTask {
             }
             processesState = transformed.join('\t')
         } catch (Exception e) {
+            System.err.println(e)
             logger.warn("Cannot process JSON returned from 'docker compose ps --format json'", e)
         }
         processesState + composeExecutor.get().execute('config') + startedServices.get().join(',')


### PR DESCRIPTION
Fixes #420 #421