### PR TITLE
Made isRequiredBy compatible with composite gradle builds

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/TasksConfigurator.groovy
@@ -6,7 +6,6 @@ import groovy.transform.PackageScope
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.provider.Provider
-import org.gradle.api.tasks.TaskDependency
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.process.JavaForkOptions
 import org.gradle.process.ProcessForkOptions
@@ -123,31 +122,26 @@ class TasksConfigurator {
     void isRequiredByCore(Task task, boolean fromConfigure) {
         task.dependsOn upTask
         task.finalizedBy downTask
-        def taskDependencies = getTaskDependencies(task)
         if (fromConfigure) {
-            upTask.get().shouldRunAfter taskDependencies
+            upTask.get().shouldRunAfter getTaskDependencies(task)
         } else {
-            upTask.configure { it.shouldRunAfter taskDependencies }
+            upTask.configure { it.shouldRunAfter getTaskDependencies(task) }
         }
         if (task instanceof ProcessForkOptions) task.doFirst { composeSettings.exposeAsEnvironment(task as ProcessForkOptions) }
         if (task instanceof JavaForkOptions) task.doFirst { composeSettings.exposeAsSystemProperties(task as JavaForkOptions) }
     }
 
-    private TaskDependency getTaskDependencies(Task task) {
+    private Object getTaskDependencies(Task task) {
         def includedBuilds = task.project.gradle.includedBuilds
         if (includedBuilds.isEmpty()) {
             return task.taskDependencies
         } else {
-            // Ignore any task dependencies from a composite/included build by delegating to a lazily filtered TaskDependency implementation
-            // to avoid the "Cannot use shouldRunAfter to reference tasks from another build" error introduced in Gradle 8
+            // Ignore any task dependencies from a composite/included build to avoid the
+            // "Cannot use shouldRunAfter to reference tasks from another build" error introduced in Gradle 8
             def includedBuildProjectNames = includedBuilds.collect { it.name }.toSet()
-            return new TaskDependency() {
-                Set<? extends Task> getDependencies(Task t) {
-                    task.taskDependencies.getDependencies(t).findAll { dependency ->
-                        // use rootProject.name in case the task is from a multi-module composite build
-                        !includedBuildProjectNames.contains(dependency.project.rootProject.name)
-                    }
-                }
+            return task.taskDependencies.getDependencies(null).findAll { dependency ->
+                // use rootProject.name in case the task is from a multi-module composite build
+                !includedBuildProjectNames.contains(dependency.project.rootProject.name)
             }
         }
     }


### PR DESCRIPTION
This change makes it possible to use `isRequiredBy` with a composite gradle build (attempting to do so currently fails with "Cannot use shouldRunAfter to reference tasks from another build"). 

See https://github.com/avast/gradle-docker-compose-plugin/issues/459 for details.

I have tested this in my [reproducer repo](https://github.com/jamesbassett/compose-plugin-reproducer) by publishing the plugin locally
* using both variants of `isRequiredBy`, i.e. supplying either
  * `tasks.getByName("test")`
  * `tasks.named<Test>("test")`
* with a composite build and a normal build

When testing the eager variant (`getByName()`) I encountered build failures on the toolchain config saying I couldn't modify it. I then realised that my use of `task.taskDependencies.getDependencies()` was eagerly creating tasks and resolving dependencies. So I changed it to use a `TaskDependency` proxy that allows the filtering to occur lazily, and the issues went away.

I've also tested it in a private repo that makes use of a multi-module composite build. It was here that I discovered I needed to make the filtering logic smarter and use the task's `rootProject.name`, as the included build name is always the root project.

In terms of configuration avoidance, I've done build scans and I don't see any tasks "Created during configuration" as a result of the plugin. In my reproducer repo I seem to get 5 as a result of using a composite build (0 when changing it to a normal multi module build), but notice no difference as a result of this plugin. It goes up to 6 if I eagerly fetch the task, i.e. `tasks.getByName("test")`.

Compatibility-wise I don't think I'm using anything risky/new/breaking from the Gradle API.

I've also minimised the risk of this change breaking anything by only attempting to filter if there are included builds (otherwise it retains the original logic).




