### PR TITLE
Fix "invalid reference format" error if nested name is not set

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeSettings.groovy
@@ -97,10 +97,10 @@ abstract class ComposeSettings {
                 return customProjectName
             }
             else if (projectNamePrefix) {
-                return "${projectNamePrefix}_${nestedName}"
+                return nestedName ? "${projectNamePrefix}_${nestedName}" : projectNamePrefix
             }
             else {
-                return "${safeProjectNamePrefix}_${nestedName}"
+                return nestedName ? "${safeProjectNamePrefix}_${nestedName}" : safeProjectNamePrefix
             }
         }).map{ String projectName ->
             // docker-compose project names must be lowercase


### PR DESCRIPTION
Fixes https://github.com/avast/gradle-docker-compose-plugin/issues/393

This turned out to be caused by the unnecessary trailing `_` in the project name logic. It now only adds it if there is a nested name to add as a suffix.

Sorry I didn't update the tests to add a docker build to replicate this, but I did test this plugin change locally against one of my projects with this issue.