### PR TITLE
fix: MissingMethodException hopefully fixed

### DIFF
--- a/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
+++ b/src/main/groovy/com/avast/gradle/dockercompose/ComposeExecutor.groovy
@@ -122,7 +122,7 @@ abstract class ComposeExecutor implements BuildService<Parameters>, AutoCloseabl
         }
     }
 
-    private String executeWithAnsi(String... args) {
+    String executeWithAnsi(String... args) {
         new ByteArrayOutputStream().withStream { os ->
             executeWithCustomOutput(os, false, false, false, args)
             os.toString().trim()
@@ -134,7 +134,7 @@ abstract class ComposeExecutor implements BuildService<Parameters>, AutoCloseabl
     VersionNumber getVersion() {
         if (cachedVersion) return cachedVersion
         String rawVersion = executeWithAnsi('version', '--short')
-        cachedVersion = VersionNumber.parse(rawVersion.startsWith('v') ? rawVersion.substring(1) : rawVersion)
+        return cachedVersion = VersionNumber.parse(rawVersion.startsWith('v') ? rawVersion.substring(1) : rawVersion)
     }
 
     Map<String,Iterable<String>> getContainerIds(List<String> serviceNames) {


### PR DESCRIPTION
Fixes #489

Cannot reproduce it in test, but it happened to me locally, so I tested it at least on my machine. Looks like there is an issue with Groovy 4, or the way how Gradle 9 handles shared services. The trick seems to be to remove the `private` from the method.